### PR TITLE
NullableBehavior unexpected null

### DIFF
--- a/src/Model/Behavior/NullableBehavior.php
+++ b/src/Model/Behavior/NullableBehavior.php
@@ -36,7 +36,7 @@ class NullableBehavior extends Behavior {
 			$associations[$association->getProperty()] = $association->getName();
 		}
 		
-		if (!is_array($data)) {
+		if (!is_array($data) || !$data instanceof ArrayObject) {
 			return $data;
 		}
 

--- a/src/Model/Behavior/NullableBehavior.php
+++ b/src/Model/Behavior/NullableBehavior.php
@@ -36,7 +36,7 @@ class NullableBehavior extends Behavior {
 			$associations[$association->getProperty()] = $association->getName();
 		}
 		
-		if (!is_array($data) || !$data instanceof ArrayObject) {
+		if (is_null($data)) {
 			return $data;
 		}
 

--- a/src/Model/Behavior/NullableBehavior.php
+++ b/src/Model/Behavior/NullableBehavior.php
@@ -35,6 +35,10 @@ class NullableBehavior extends Behavior {
 		foreach ($table->associations() as $association) {
 			$associations[$association->getProperty()] = $association->getName();
 		}
+		
+		if (!is_array($data)) {
+			return $data;
+		}
 
 		foreach ($data as $key => $value) {
 			if (array_key_exists($key, $associations)) {


### PR DESCRIPTION
In NullableBehavior I'm running into an instance where the `_process($data, Table $table)` method has a null $data. This PR adds a check to see if the `$data` is null and then returns the data as is if it is null.