### PR TITLE
Ignore the framework's model Permission

### DIFF
--- a/Model/ShimModel.php
+++ b/Model/ShimModel.php
@@ -33,7 +33,7 @@ class ShimModel extends Model {
 	 * @param string|null $ds
 	 */
 	public function __construct($id = false, $table = null, $ds = null) {
-		if ($this->getAssociated()) {
+		if ($this->getAssociated() && get_class($this) !== 'Permission') {
 			$message = 'Relations must be defined using $this->initialized() in ' . get_class($this);
 			Shim::check(Shim::RELATIONSHIP_PROPERTIES, $message);
 		}


### PR DESCRIPTION
```
 Relations must be defined using $this->initialized() in Permission

.../app/Plugin/Shim/Lib/Shim.php:113
.../app/Plugin/Shim/Model/ShimModel.php:38
.../app/Model/AppModel.php:103
.../Cake/Model/Permission.php:63
.../Cake/Utility/ClassRegistry.php:169
```