### PR TITLE
Add Entity getOrFail() trait.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - if [[ $PREFER_LOWEST != 1 ]]; then composer install --prefer-source --no-interaction ; fi
   - if [[ $PREFER_LOWEST == 1 ]]; then composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction ; fi
 
-  - if [[ $CHECKS != 1 ]]; then composer require --dev phpunit/phpunit:"^5.7.27|^6.5.14" sebastian/diff --update-with-all-dependencies ; fi
+  - if [[ $CHECKS != 1 ]]; then composer require --dev phpunit/phpunit:"^5.7.27|^6.5.14" sebastian/diff:"^1.4|^2.0|^3.0" --update-with-all-dependencies ; fi
 
   - if [[ $DB == 'mysql' ]]; then mysql -e 'CREATE DATABASE cakephp_test;' ; fi
   - if [[ $DB == 'pgsql' ]]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - if [[ $PREFER_LOWEST != 1 ]]; then composer install --prefer-source --no-interaction ; fi
   - if [[ $PREFER_LOWEST == 1 ]]; then composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction ; fi
 
-  - if [[ $CHECKS != 1 ]]; then composer require --dev phpunit/phpunit:"^5.7.27|^6.5.14" sebastian/diff:"^2.0" --update-with-all-dependencies ; fi
+  - if [[ $CHECKS != 1 ]]; then composer require --dev phpunit/phpunit:"^5.7.27|^6.5.14" sebastian/diff --update-with-all-dependencies ; fi
 
   - if [[ $DB == 'mysql' ]]; then mysql -e 'CREATE DATABASE cakephp_test;' ; fi
   - if [[ $DB == 'pgsql' ]]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,14 @@ matrix:
     - php: 7.2
       env: CODECOVERAGE=1 DEFAULT=0 DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test'
 
+before_install:
+  - if [[ $CODECOVERAGE != 1 ]]; then phpenv config-rm xdebug.ini; fi
+
 before_script:
   - if [[ $PREFER_LOWEST != 1 ]]; then composer install --prefer-source --no-interaction ; fi
   - if [[ $PREFER_LOWEST == 1 ]]; then composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction ; fi
 
-  - if [[ $CHECKS != 1 ]]; then composer require --dev phpunit/phpunit:"^5.7.14|^6.0" --update-with-all-dependencies ; fi
+  - if [[ $CHECKS != 1 ]]; then composer require --dev phpunit/phpunit:"^5.7.27|^6.5.14" sebastian/diff:"^2.0" --update-with-all-dependencies ; fi
 
   - if [[ $DB == 'mysql' ]]; then mysql -e 'CREATE DATABASE cakephp_test;' ; fi
   - if [[ $DB == 'pgsql' ]]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   - if [[ $PREFER_LOWEST != 1 ]]; then composer install --prefer-source --no-interaction ; fi
   - if [[ $PREFER_LOWEST == 1 ]]; then composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction ; fi
 
-  - if [[ $CHECKS != 1 ]]; then composer require --dev phpunit/phpunit:"^5.7.14|^6.0" ; fi
+  - if [[ $CHECKS != 1 ]]; then composer require --dev phpunit/phpunit:"^5.7.14|^6.0" --update-with-all-dependencies ; fi
 
   - if [[ $DB == 'mysql' ]]; then mysql -e 'CREATE DATABASE cakephp_test;' ; fi
   - if [[ $DB == 'pgsql' ]]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
 		"cakephp/cakephp": "^3.7.0"
 	},
 	"require-dev": {
+		"dereuromark/cakephp-ide-helper": "^0.13.11",
 		"fig-r/psr2r-sniffer": "dev-master"
 	},
 	"support": {

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -125,6 +125,25 @@ $articles->connection()->transactional(function () use ($articles, $entities) {
 }
 ```
 
+### Entity get...OrFail()
+You want to use "asserted return values" or "safe chaining" in your entities?
+Then you want to ensure you are not getting null values returned where you expect actual values.
+
+Add the trait first:
+```php
+class MyEntity extends Entity {
+	use GetTrait;
+```
+
+Use the included annotator to get all method annotations into your entities:
+```php
+'IdeHelper' => [
+	'annotators' => [
+		\IdeHelper\Annotator\EntityAnnotator::class => \Shim\Annotator\EntityAnnotator::class,
+	],
+```
+This replaces the native one and adds support for these get methods on top.
+
 
 ## Database
 

--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Shim\Annotator;
+
+use Cake\Utility\Inflector;
+use IdeHelper\Annotation\MethodAnnotation;
+use IdeHelper\Annotator\EntityAnnotator as IdeHelperEntityAnnotator;
+use IdeHelper\View\Helper\DocBlockHelper;
+
+class EntityAnnotator extends IdeHelperEntityAnnotator {
+
+	/**
+	 * @param array $propertyHintMap
+	 * @param \IdeHelper\View\Helper\DocBlockHelper $helper
+	 *
+	 * @return \IdeHelper\Annotation\AbstractAnnotation[]
+	 * @throws \RuntimeException
+	 */
+	protected function buildAnnotations(array $propertyHintMap, DocBlockHelper $helper) {
+		$map = parent::buildAnnotations($propertyHintMap, $helper);
+
+		$class = $this->getConfig('class');
+		if (!$class || !method_exists($class, 'getOrFail')) {
+			return $map;
+		}
+
+		foreach ($propertyHintMap as $field => $type) {
+			$method = 'get' . Inflector::camelize($field) . 'OrFail()';
+			if (strpos($type, '|null') !== false) {
+				$type = str_replace('|null', '', $type);
+			}
+
+			$map[] = new MethodAnnotation($type, $method);
+		}
+
+		return $map;
+	}
+
+}

--- a/src/Model/Entity/GetTrait.php
+++ b/src/Model/Entity/GetTrait.php
@@ -1,0 +1,34 @@
+<?php
+namespace Shim\Model\Entity;
+
+use Cake\Utility\Inflector;
+use RuntimeException;
+
+/**
+ * Trait to read entity properties in a way that the return value is ensured.
+ *
+ * - get{PropertyName}OrFail() must return the property or throws exception otherwise
+ */
+trait GetTrait {
+
+	/**
+	 * @param string $name
+	 * @param array $arguments
+	 * @return mixed
+	 * @throws \RuntimeException
+	 */
+	public function __call($name, array $arguments) {
+		if (!preg_match('/get([A-Z][A-Za-z0-9]+)OrFail/', $name, $matches)) {
+			throw new RuntimeException('Method ' . $name . ' cannot be found; get{PropertyName}OrFail() expected.');
+		}
+
+		$property = Inflector::underscore($matches[1]);
+
+		if (!isset($this->$property)) {
+			throw new RuntimeException('$' . $property . ' is null, expected non-null value.');
+		}
+
+		return $this->$property;
+	}
+
+}

--- a/src/Model/Entity/GetTrait.php
+++ b/src/Model/Entity/GetTrait.php
@@ -12,6 +12,19 @@ use RuntimeException;
 trait GetTrait {
 
 	/**
+	 * @param string $property
+	 * @return mixed
+	 * @throws \RuntimeException
+	 */
+	public function getOrFail($property) {
+		if (!isset($this->$property)) {
+			throw new RuntimeException('$' . $property . ' is null, expected non-null value.');
+		}
+
+		return $this->$property;
+	}
+
+	/**
 	 * @param string $name
 	 * @param array $arguments
 	 * @return mixed
@@ -24,11 +37,7 @@ trait GetTrait {
 
 		$property = Inflector::underscore($matches[1]);
 
-		if (!isset($this->$property)) {
-			throw new RuntimeException('$' . $property . ' is null, expected non-null value.');
-		}
-
-		return $this->$property;
+		return $this->getOrFail($property);
 	}
 
 }

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -3,8 +3,8 @@
 namespace Shim\Test\TestCase\Annotator;
 
 use Cake\I18n\FrozenTime;
-use IdeHelper\View\Helper\DocBlockHelper;
 use Cake\View\View;
+use IdeHelper\View\Helper\DocBlockHelper;
 use ReflectionClass;
 use Shim\Annotator\EntityAnnotator;
 use Shim\TestSuite\TestCase;
@@ -16,7 +16,7 @@ class EntityAnnotatorTest extends TestCase {
 	 * @return void
 	 */
 	public function testBuildAnnotations() {
-		/** @var EntityAnnotator $entityAnnotator */
+		/** @var \Shim\Annotator\EntityAnnotator $entityAnnotator */
 		$entityAnnotator = $this->getMockBuilder(EntityAnnotator::class)->disableOriginalConstructor()->setMethods(['annotate'])->getMock();
 		$entityAnnotator->setConfig('class', TestEntity::class);
 

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Shim\Test\TestCase\Annotator;
+
+use Cake\I18n\FrozenTime;
+use IdeHelper\View\Helper\DocBlockHelper;
+use Cake\View\View;
+use ReflectionClass;
+use Shim\Annotator\EntityAnnotator;
+use Shim\TestSuite\TestCase;
+use TestApp\Model\Entity\TestEntity;
+
+class EntityAnnotatorTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testBuildAnnotations() {
+		/** @var EntityAnnotator $entityAnnotator */
+		$entityAnnotator = $this->getMockBuilder(EntityAnnotator::class)->disableOriginalConstructor()->setMethods(['annotate'])->getMock();
+		$entityAnnotator->setConfig('class', TestEntity::class);
+
+		$propertyHintMap = ['id' => 'int', 'foo_bar' => '\\' . FrozenTime::class . '|null'];
+		$helper = new DocBlockHelper(new View());
+
+		/** @var \IdeHelper\Annotation\AbstractAnnotation[] $result */
+		$result = $this->invokeMethod($entityAnnotator, 'buildAnnotations', [$propertyHintMap, $helper]);
+		$this->assertCount(4, $result);
+
+		$this->assertSame('int $id', $result[0]->build());
+		$this->assertSame('\\' . FrozenTime::class . '|null $foo_bar', $result[1]->build());
+		$this->assertSame('int getIdOrFail()', $result[2]->build());
+		$this->assertSame('\\' . FrozenTime::class . ' getFooBarOrFail()', $result[3]->build());
+	}
+
+	/**
+	 * @param object &$object Instantiated object that we will run method on.
+	 * @param string $methodName Method name to call.
+	 * @param array $parameters Array of parameters to pass into method.
+	 *
+	 * @return mixed Method return.
+	 */
+	protected function invokeMethod(&$object, $methodName, array $parameters = []) {
+		$reflection = new ReflectionClass(get_class($object));
+		$method = $reflection->getMethod($methodName);
+		$method->setAccessible(true);
+
+		return $method->invokeArgs($object, $parameters);
+	}
+
+}

--- a/tests/TestCase/Model/Entity/EntityGetTest.php
+++ b/tests/TestCase/Model/Entity/EntityGetTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Shim\Test\TestCase\Model\Entity;
+
+use RuntimeException;
+use Shim\TestSuite\TestCase;
+use TestApp\Model\Entity\TestEntity;
+
+class EntityGetTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testGet() {
+		$entity = new TestEntity();
+		$entity->foo_bar = 'Foo Bar';
+
+		$result = $entity->getFooBarOrFail();
+		$expected = 'Foo Bar';
+		$this->assertSame($expected, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetFail() {
+		$entity = new TestEntity();
+
+		$this->expectException(RuntimeException::class);
+
+		$entity->getFooBarOrFail();
+	}
+
+}

--- a/tests/TestCase/Model/Entity/EntityGetTest.php
+++ b/tests/TestCase/Model/Entity/EntityGetTest.php
@@ -11,24 +11,38 @@ class EntityGetTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testGet() {
+	public function testGetOrFail() {
 		$entity = new TestEntity();
 		$entity->foo_bar = 'Foo Bar';
 
 		$result = $entity->getFooBarOrFail();
 		$expected = 'Foo Bar';
 		$this->assertSame($expected, $result);
+
+		$result = $entity->getOrFail('foo_bar');
+		$this->assertSame($expected, $result);
 	}
 
 	/**
 	 * @return void
 	 */
-	public function testGetFail() {
+	public function testGetOrFailMagicInvalid() {
 		$entity = new TestEntity();
 
 		$this->expectException(RuntimeException::class);
 
 		$entity->getFooBarOrFail();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetOrFailInvalid() {
+		$entity = new TestEntity();
+
+		$this->expectException(RuntimeException::class);
+
+		$entity->getOrFail('foo_bar');
 	}
 
 }

--- a/tests/test_app/src/Model/Entity/TestEntity.php
+++ b/tests/test_app/src/Model/Entity/TestEntity.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+use Shim\Model\Entity\GetTrait;
+
+/**
+ * @property string|null $foo_bar
+ * @method string getFooBarOrFail()
+ */
+class TestEntity extends Entity {
+
+	use GetTrait;
+
+}


### PR DESCRIPTION
This would allow us to use entity properties typehinted and return type safe.
No null pointer occurance, as the returned value must be non-null for getFooOrFail() - similar to other core usage - or [Dto](https://github.com/dereuromark/cakephp-dto) one.

To get the typehints one would need to add an [IdeHelper task](https://github.com/dereuromark/cakephp-ide-helper) to generate those annotations.
The Shim plugin could provide this task and it can be added to the task collection if one uses this trait.

This is a requirement if you want to use static analyzers for your code base - like PHPStan level 5+.

Question:
Do we also want to add readOrFail($string) for dot syntax, to more easily get nested data?
read('users.0.prop') etc?