### PR TITLE
Add Entity read() method.

### DIFF
--- a/docs/Features.md
+++ b/docs/Features.md
@@ -125,12 +125,33 @@ $articles->connection()->transactional(function () use ($articles, $entities) {
 }
 ```
 
+### Entity read()
+You want to read nested properties of your entity, but you do not want tons of !empty() checks?
+```
+if (!empty($entity->tags && !empty($entity->tags[2]->name)) {} else {}
+```
+
+Add the trait first:
+```php
+use Shim\Model\Entity\ReadTrait;
+
+class MyEntity extends Entity {
+	use ReadTrait;
+```
+
+Then you can use it like this:
+```php
+echo $entity->read('tags.2.name', $default);
+```
+
 ### Entity get...OrFail()
 You want to use "asserted return values" or "safe chaining" in your entities?
 Then you want to ensure you are not getting null values returned where you expect actual values.
 
 Add the trait first:
 ```php
+use Shim\Model\Entity\GetTrait;
+
 class MyEntity extends Entity {
 	use GetTrait;
 ```

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -144,6 +144,9 @@ Then you can use it like this:
 echo $entity->read('tags.2.name', $default);
 ```
 
+This means, you are OK with part of the path being empty/null.
+If you want the opposite, making sure all required fields in the path are present, check the next part about getOrFail().
+
 ### Entity get...OrFail()
 You want to use "asserted return values" or "safe chaining" in your entities?
 Then you want to ensure you are not getting null values returned where you expect actual values.

--- a/src/Model/Entity/ReadTrait.php
+++ b/src/Model/Entity/ReadTrait.php
@@ -1,0 +1,62 @@
+<?php
+namespace Shim\Model\Entity;
+
+use ArrayAccess;
+use Cake\Datasource\EntityInterface;
+
+/**
+ * Trait to read entity properties in a way that it doesnt throw exception if parts of the path are null.
+ *
+ * - read('tags.0.name') will return the property if it exists or returns null otherwise
+ *
+ * Note: This is primarily for convenience usage in view templates, as the return type cannot be annotated here.
+ *
+ * @mixin \Cake\ORM\Entity
+ */
+trait ReadTrait {
+
+	/**
+	 * Performant iteration over the path to nullable read the property path.
+	 *
+	 * Note: Hash::get($this->toArray(), $path, $default); would be simpler, but slower.
+	 *
+	 * @param string $path
+	 * @param mixed $default The return value when the path does not exist
+	 * @return mixed|null The value fetched from the entity, or null.
+	 */
+	public function read($path, $default = null) {
+		if (isset($this->$path)) {
+			return $this->$path;
+		}
+
+		if (strpos($path, '.') === false) {
+			return $default;
+		}
+
+		$parts = explode('.', $path);
+
+		$data = null;
+		foreach ($parts as $key) {
+			if ($data === null && !isset($this->$key)) {
+				return $default;
+			}
+			if ($data === null) {
+				$data = $this->$key;
+				continue;
+			}
+
+			if ($data instanceof EntityInterface) {
+				$data = $data->toArray();
+			}
+
+			if ((is_array($data) || $data instanceof ArrayAccess) && isset($data[$key])) {
+				$data = $data[$key];
+			} else {
+				return $default;
+			}
+		}
+
+		return $data;
+	}
+
+}

--- a/tests/TestCase/Model/Entity/EntityReadTest.php
+++ b/tests/TestCase/Model/Entity/EntityReadTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Shim\Test\TestCase\Model\Entity;
+
+use Cake\ORM\Entity;
+use Shim\TestSuite\TestCase;
+use TestApp\Model\Entity\TestEntity;
+
+class EntityReadTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testRead() {
+		$entity = new TestEntity();
+		$entity->foo_bar = 'Foo Bar';
+
+		$result = $entity->read('foo_bar');
+		$expected = 'Foo Bar';
+		$this->assertSame($expected, $result);
+
+		$result = $entity->read('invalid');
+		$this->assertNull($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReadDeep() {
+		$entity = new TestEntity();
+
+		$entity->tags = [
+			new Entity(),
+			new Entity(),
+			new Entity(['name' => 'foo']),
+		];
+
+		$result = $entity->read('tags.2.name');
+
+		$this->assertSame('foo', $result);
+	}
+
+}

--- a/tests/TestCase/Model/Entity/EntityReadTest.php
+++ b/tests/TestCase/Model/Entity/EntityReadTest.php
@@ -36,8 +36,44 @@ class EntityReadTest extends TestCase {
 		];
 
 		$result = $entity->read('tags.2.name');
-
 		$this->assertSame('foo', $result);
+
+		$result = $entity->read('tags.2.name_not_exists');
+		$this->assertNull($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReadDefaultValue() {
+		$entity = new TestEntity();
+		$entity->foo_bar = 'Foo Bar';
+
+		$result = $entity->read('foo_bar', false);
+		$expected = 'Foo Bar';
+		$this->assertSame($expected, $result);
+
+		$result = $entity->read('invalid', false);
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReadDeepDefaultValue() {
+		$entity = new TestEntity();
+
+		$entity->tags = [
+			new Entity(),
+			new Entity(),
+			new Entity(['name' => new Entity(['subname' => 'foo'])]),
+		];
+
+		$result = $entity->read('tags.2.name.subname', false);
+		$this->assertSame('foo', $result);
+
+		$result = $entity->read('tags.2.name.subname_not_exists', false);
+		$this->assertFalse($result);
 	}
 
 }

--- a/tests/test_app/src/Model/Entity/TestEntity.php
+++ b/tests/test_app/src/Model/Entity/TestEntity.php
@@ -4,6 +4,7 @@ namespace TestApp\Model\Entity;
 
 use Cake\ORM\Entity;
 use Shim\Model\Entity\GetTrait;
+use Shim\Model\Entity\ReadTrait;
 
 /**
  * @property string|null $foo_bar
@@ -12,5 +13,6 @@ use Shim\Model\Entity\GetTrait;
 class TestEntity extends Entity {
 
 	use GetTrait;
+	use ReadTrait;
 
 }


### PR DESCRIPTION
This implements the idea of https://github.com/cakephp/cakephp/issues/11792 as trait to opt-in
Add to your entities to allow read() access like in other parts of the framework, for entities' properties.

`$entity->read('tags.0.name')` will return the property if it exists or returns null otherwise

Saves you a lot of empty checks, if you are OK with parts of the path being "empty".
This works well together with getOrFail() methods that do the opposite: They ensure the path cannot be empty for the use cases where you absolutely require it.