### PR TITLE
Add basic time type handling.

### DIFF
--- a/docs/Database/Time.md
+++ b/docs/Database/Time.md
@@ -1,0 +1,57 @@
+# Time Type classes
+
+## TimeStringType
+The `TimeStringType` can be used to represent a specific string field for `HH:MM:SS` times.
+It keeps the string type, but makes sure the format is normalized and valid.
+
+Besides string input, it can also accept the Cake dropdown select values from a default time control:
+
+```php
+$data = [
+    ...
+    'closing_time' => [
+        'hour' => '1',
+        'minute' => '12',
+        'second' => '20',
+    ],
+];
+$entity = $this->Table->newEntity($data);
+// $entity->closing_time is now 01:12:20
+```
+
+To set it up for a specific field:
+```php
+// In your Table class
+protected function _initializeSchema(Table $table) {
+    $table->columnType('closing_time', 'time');
+    ...
+    return $table;
+}
+```
+
+Then make sure you mapped the type to a class in your config:
+```php
+// In your bootstrap
+use Cake\Database\Type;
+Type::map('time', 'Shim\Database\Type\TimeStringType');
+```
+
+If you want to disable `24:00:00` as valid upper boundary (and transform it to `00:00:00` instead): 
+```php
+// in your bootstrap
+\Shim\Database\Type\TimeStringType::$normalizeUpperBoundary = true;
+```
+
+
+## What about objects?
+We could also think about a value object representing time.
+This way you could offer a bit more functionality:
+- format() with e.g. only `HH:MM` etc - but most of this can already be done on presentation layer via helper
+- diff() in `HH:MM::SS` or `\DateInterval`
+- isSame()/isBefore()/isAfter() methods
+- fromDateTime() and alike to extract the time part
+
+Even custom localized formatting like `AM/PM` could be added, but I think this should really be kept rather 
+in the presentation layer to keep such logic out of the value object itself.
+
+Feel free to add a `TimeObjectType` class here.

--- a/docs/Database/Uuid.md
+++ b/docs/Database/Uuid.md
@@ -1,0 +1,29 @@
+# UUID type classes
+
+## BinaryUuidType
+
+### UUID as BINARY(36)
+Currently CakePHP still mainly only supports/promotes CHAR(36).
+The BINARY types are much more [performant](http://iops.io/blog/storing-billions-uuid-fields-mysql-innodb/), though.
+
+The clean way would be to mark those columns as type `uuid` manually:
+```php
+// In your Table class
+protected function _initializeSchema(Table $table) {
+    $table->columnType('id', 'uuid');
+    ...
+    return $table;
+}
+```
+
+But if you have many UUID columns for primary and foreign keys, you might want to use a more automatic approach.
+If you upgrade 2.x apps that use the BINARY(36) type, you can use the Shim plugin's custom type class:
+
+```php
+// In your bootstrap
+use Cake\Database\Type;
+Type::map('binary', 'Shim\Database\Type\BinaryType');
+```
+
+Note: BINARY(16) would even be more performant, but then you would need to manually hex() and unhex() directly in the database.
+So at this point this cannot be supported yet.

--- a/docs/Database/Year.md
+++ b/docs/Database/Year.md
@@ -1,0 +1,11 @@
+# Year Type class
+
+## YearType
+The `YearType` can be used to represent a year in the DB as integer value.
+
+Apart from string form input it can also accept the default Cake datetime control array form.
+
+Setup:
+
+- `Type::map('year', 'Shim\Database\Type\YearType');` in bootstrap
+- Manual FormHelper `$this->Form->control('published', ['type' => 'year']);`

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -85,34 +85,6 @@ $articles->connection()->transactional(function () use ($articles, $entities) {
 Note: In 4x. this will be coming as `saveMany()`/`saveManyOrFail()`.
 
 
-## Database
-
-### UUID as BINARY(36)
-Currently CakePHP still mainly only supports/promotes CHAR(36).
-The BINARY types are much more [performant](http://iops.io/blog/storing-billions-uuid-fields-mysql-innodb/), though.
-
-The clean way would be to mark those columns as type `uuid` manually:
-```php
-// In your Table class
-protected function _initializeSchema(Table $table) {
-    $table->columnType('id', 'uuid');
-    ...
-    return $table;
-}
-```
-
-But if you have many UUID columns for primary and foreign keys, you might want to use a more automatic approach.
-If you upgrade 2.x apps that use the BINARY(36) type, you can use the Shim plugin's custom type class:
-
-```php
-// In your bootstrap
-use Cake\Database\Type;
-Type::map('binary', 'Shim\Database\Type\BinaryType');
-```
-
-Note: BINARY(16) would even be more performant, but then you would need to manually hex() and unhex() directly in the database.
-So at this point this cannot be supported yet.
-
 ## Utility
 
 ### Set

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,12 @@ Model
 - [Entity Get/Fail](Model/Entity.md)
 - [Nullable](Model/Nullable.md)
 
+Database
+- [UUID type](Database/Uuid.md)
+- [Time type](Database/Time.md)
+- [Year type](Database/Year.md)
+- [Json type](Database/Json.md)
+
 ## BC shims
 The following shims are only in place for 2.x => 3.x and can possibly be removed in the future.
 

--- a/src/Database/Type/TimeStringType.php
+++ b/src/Database/Type/TimeStringType.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Shim\Database\Type;
+
+use Cake\Database\Driver;
+use Cake\Database\Type;
+use PDO;
+
+/**
+ * Experimental time type (as string)
+ *
+ * Needs:
+ * - Type::map('time', 'Shim\Database\Type\TimeStringType'); in bootstrap
+ * - Manual FormHelper $this->Form->control('closing_time', ['type' => 'time']);
+ */
+class TimeStringType extends Type {
+
+	/**
+	 * If 24:00:00 should be normalized to 00:00:00, defaults to false as this could change
+	 * meaning in time diffs.
+	 *
+	 * @var bool
+	 */
+	public static $normalizeUpperBoundary = false;
+
+	/**
+	 * @param int|string|array|null $value The value to convert.
+	 * @param \Cake\Database\Driver $driver The driver instance to convert with.
+	 * @return int|null
+	 */
+	public function toDatabase($value, Driver $driver) {
+		if (is_array($value)) {
+			$value = $this->fromArray($value);
+		}
+		if ($value !== null) {
+			$value = $this->normalize($value);
+		}
+		if ($value === null) {
+			return null;
+		}
+		return $value;
+	}
+
+	/**
+	 * Convert binary into resource handles
+	 *
+	 * @param string|null $value The value to convert.
+	 * @param \Cake\Database\Driver $driver The driver instance to convert with.
+	 * @return string|null
+	 */
+	public function toPHP($value, Driver $driver) {
+		if ($value === null) {
+			return null;
+		}
+		return $value;
+	}
+
+	/**
+	 * Get the correct PDO binding type for time data.
+	 *
+	 * @param mixed $value The value being bound.
+	 * @param \Cake\Database\Driver $driver The driver.
+	 * @return int
+	 */
+	public function toStatement($value, Driver $driver) {
+		return PDO::PARAM_STR;
+	}
+
+	/**
+	 * @param array $value
+	 *
+	 * @return string|null
+	 */
+	protected function fromArray(array $value) {
+		$hours = isset($value['hour']) ? str_pad($value['hour'], 2, '0', STR_PAD_LEFT) : '00';
+		$minutes = isset($value['minute']) ? str_pad($value['minute'], 2, '0', STR_PAD_LEFT) : '00';
+		$seconds = isset($value['second']) ? str_pad($value['second'], 2, '0', STR_PAD_LEFT) : '00';
+
+		return $hours . ':' . $minutes . ':' . $seconds;
+	}
+
+	/**
+	 * @param string $value
+	 * @return string|null
+	 */
+	protected function normalize($value) {
+		if (!preg_match('#^(([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|24:00:00)$#', $value)) {
+			return null;
+		}
+		if (static::$normalizeUpperBoundary && $value === '24:00:00') {
+			return '00:00:00';
+		}
+
+		return $value;
+	}
+
+}

--- a/src/Database/Type/TimeStringType.php
+++ b/src/Database/Type/TimeStringType.php
@@ -24,9 +24,9 @@ class TimeStringType extends Type {
 	public static $normalizeUpperBoundary = false;
 
 	/**
-	 * @param int|string|array|null $value The value to convert.
+	 * @param string|array|null $value The value to convert.
 	 * @param \Cake\Database\Driver $driver The driver instance to convert with.
-	 * @return int|null
+	 * @return string|null
 	 */
 	public function toDatabase($value, Driver $driver) {
 		if (is_array($value)) {

--- a/tests/Fixture/TimeTypesFixture.php
+++ b/tests/Fixture/TimeTypesFixture.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Shim\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class TimeTypesFixture extends TestFixture {
+
+	/**
+	 * Fields
+	 *
+	 * @var array
+	 */
+	public $fields = [
+		'id' => ['type' => 'integer'],
+		'name' => ['type' => 'string', 'null' => true],
+		'closing_time' => ['type' => 'string', 'length' => 8, 'null' => true],
+		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+	];
+
+	/**
+	 * Records property
+	 *
+	 * @var array
+	 */
+	public $records = [
+		[
+			'name' => 'Some room',
+			'closing_time' => '20:00:00',
+		],
+	];
+
+}

--- a/tests/TestCase/Database/Type/TimeStringTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeStringTypeTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Shim\Test\TestCase\Database\Type;
+
+use Cake\Database\Type;
+use Cake\ORM\TableRegistry;
+use Cake\View\Helper\FormHelper;
+use Cake\View\View;
+use Shim\Database\Type\TimeStringType;
+use Shim\TestSuite\TestCase;
+use TestApp\Model\Table\TimeTypesTable;
+
+class TimeStringTypeTest extends TestCase {
+
+	/**
+	 * @var array
+	 */
+	public $fixtures = [
+		'plugin.Shim.TimeTypes'
+	];
+
+	/**
+	 * @var \Shim\Model\Table\Table
+	 */
+	public $Table;
+
+	/**
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		Type::map('time', TimeStringType::class);
+
+		$this->Table = TableRegistry::get('TimeStringTypes', ['className' => TimeTypesTable::class]);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		unset($this->Table);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSave() {
+		$data = [
+			'name' => 'Foo',
+			'closing_time' => '21:10:00',
+		];
+		$entity = $this->Table->newEntity($data);
+		$this->Table->save($entity);
+
+		$record = $this->Table->get($entity->id);
+		$this->assertSame($data['closing_time'], $record->closing_time);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSaveInvalid() {
+		$data = [
+			'name' => 'Foo',
+			'closing_time' => '25:10:00',
+		];
+		$entity = $this->Table->newEntity($data);
+		$this->Table->save($entity);
+
+		$record = $this->Table->get($entity->id);
+		$this->assertNull($record->closing_time);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSaveArray() {
+		$data = [
+			'name' => 'Foo',
+			'closing_time' => [
+				'hour' => '1',
+				'minute' => '12',
+				'second' => '20'
+			]
+		];
+		$entity = $this->Table->newEntity($data);
+		$result = $this->Table->save($entity);
+		$this->assertTrue((bool)$result);
+
+		$record = $this->Table->get($entity->id);
+		$this->assertSame('01:12:20', $record->closing_time);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFormControl() {
+		$Form = new FormHelper(new View());
+
+		$entity = $this->Table->newEntity();
+		$Form->create($entity);
+		$x = $Form->control('closing_time', ['type' => 'time']);
+		$this->assertContains('<div class="input time"><label>Closing Time</label><select name="closing_time[hour]', $x);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSaveNormalizeUpperBoundary() {
+		TimeStringType::$normalizeUpperBoundary = true;
+
+		$data = [
+			'name' => 'Foo',
+			'closing_time' => '24:00:00',
+		];
+		$entity = $this->Table->newEntity($data);
+		$this->Table->save($entity);
+
+		$record = $this->Table->get($entity->id);
+		$this->assertSame('00:00:00', $record->closing_time);
+
+		TimeStringType::$normalizeUpperBoundary = false;
+	}
+
+}

--- a/tests/test_app/src/Model/Table/TimeTypesTable.php
+++ b/tests/test_app/src/Model/Table/TimeTypesTable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TestApp\Model\Table;
+
+use Cake\Database\Schema\TableSchema;
+use Shim\Model\Table\Table;
+
+class TimeTypesTable extends Table {
+
+	/**
+	 * @param \Cake\Database\Schema\TableSchema $schema
+	 *
+	 * @return \Cake\Database\Schema\TableSchema
+	 */
+	protected function _initializeSchema(TableSchema $schema) {
+		$schema->setColumnType('closing_time', 'time');
+
+		return $schema;
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/13440 for now
String only at this time.

Waiting for Chronos to have an object representation to go into that direction.
Or we implement sth here too (TimeObjectType with Time value object) and see where it goes.