### PR TITLE
PHP 74 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 php:
   - 5.6
-  - 7.3
+  - 7.4
 
 env:
   matrix:
@@ -24,20 +24,20 @@ matrix:
     - php: 5.6
       env: PREFER_LOWEST=1
 
-    - php: 7.2
+    - php: 7.3
       env: CHECKS=1 DEFAULT=0
 
-    - php: 7.2
+    - php: 7.3
       env: CODECOVERAGE=1 DEFAULT=0 DB=mysql DB_DSN='mysql://root@127.0.0.1/cakephp_test'
 
 before_install:
-  - if [[ $CODECOVERAGE != 1 ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $CODECOVERAGE != 1 && ${TRAVIS_PHP_VERSION} != "7.4" ]]; then phpenv config-rm xdebug.ini; fi
 
 before_script:
+  - if [[ ${TRAVIS_PHP_VERSION} == "5.6" ]]; then composer require --dev phpunit/phpunit-mock-objects:^3.4.4; fi
+
   - if [[ $PREFER_LOWEST != 1 ]]; then composer install --prefer-source --no-interaction ; fi
   - if [[ $PREFER_LOWEST == 1 ]]; then composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction ; fi
-
-  - if [[ $CHECKS != 1 ]]; then composer require --dev phpunit/phpunit:"^5.7.27|^6.5.14" sebastian/diff:"^1.4|^2.0|^3.0" --update-with-all-dependencies ; fi
 
   - if [[ $DB == 'mysql' ]]; then mysql -e 'CREATE DATABASE cakephp_test;' ; fi
   - if [[ $DB == 'pgsql' ]]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
 	},
 	"require-dev": {
 		"dereuromark/cakephp-ide-helper": "^0.13.11",
-		"fig-r/psr2r-sniffer": "dev-master"
+		"fig-r/psr2r-sniffer": "dev-master",
+		"phpunit/phpunit": "^5.7.27|^6.5",
+		"phpunit/phpunit-mock-objects": "dev-php74 as 5.0.9"
 	},
 	"support": {
 		"source": "https://github.com/dereuromark/cakephp-shim"
@@ -36,6 +38,12 @@
 			"TestApp\\": "tests/test_app/src/"
 		}
 	},
+	"repositories": [
+		{
+			"type": "git",
+			"url": "https://github.com/dereuromark/phpunit-mock-objects.git"
+		}
+	],
 	"scripts": {
 		"test": "php phpunit.phar",
 		"test-setup": "[ ! -f phpunit.phar ] && wget https://phar.phpunit.de/phpunit-6.5.13.phar && mv phpunit-6.5.13.phar phpunit.phar || true",


### PR DESCRIPTION
Either this - or we bump php min to 7.0+ for this plugin and other ecosystem plugins.

Main requirement right now:
- Use custom "phpunit/phpunit-mock-objects" package as the existing one is broken for 7.4 and not maintained anymore unfortunately :/

I am not sure yet, but the overhead of php5.6 support is getter more and more.