### PR TITLE
Backport addFixture() for 3.9+ as FC Shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ A full overview of all shimming between 2.x and 3.x can be found in the [Wiki](h
 - Auto-adds Timestamp behavior if `created` or `modified` field exists in table.
 - Get/Read trait for clean and speaking entity access.
 
-## Backwords Compatibility shims 
-Only for 2.x => 3.x shimming: Ccontinue to provide support for some 2.x functioality in 3.x.
+## Backword Compatibility shims
+Only for 2.x => 3.x shimming: Continue to provide support for some 2.x functionality in 3.x.
 
 - Contains Session component as compatibility wrapper for request session object (and Session helper).
 - Primary level `Table::find('first')` support.
@@ -47,14 +47,15 @@ relations (`$belongsTo`, `$hasMany`, ...) as it would be very time-consuming to
 manually adjust all those.
 - Shims controller `$uses` with deprecation warning.
 
-## Forwards Compatibility shims 
+## Forwards Compatibility shims
 For 4.x compatibility of 3.x apps: Make your 3.x app future proof.
 
 - Controller referer() local security fix
 - BoolType, StringType, DecimalType, JsonType behave like in 4.x
 - Table newEmptyEntity() method available
+- TestCase::addFixture() chainable and autocompleable method available.
 
-## Deprecation help 
+## Deprecation help
 For 3.x => 4.x: Report early on about what can be changed to prepare for 4.x.
 
 - `UrlHelper::build()`

--- a/src/TestSuite/FixtureTrait.php
+++ b/src/TestSuite/FixtureTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Shim\TestSuite;
+
+use RuntimeException;
+
+/**
+ * FC shim for TestCase::addFixture()
+ *
+ * @mixin \Cake\TestSuite\TestCase
+ */
+trait FixtureTrait {
+
+	/**
+	 * Adds a fixture to this test case.
+	 *
+	 * Examples:
+	 * - core.Tags
+	 * - app.MyRecords
+	 * - plugin.MyPluginName.MyModelName
+	 *
+	 * @param string $fixture Fixture
+	 * @return $this
+	 */
+	protected function addFixture($fixture) {
+		if (!isset($this->fixtures)) {
+			$this->fixtures = [];
+		}
+		if (is_string($this->fixtures)) {
+			throw new RuntimeException('You must be using type array for $fixture property.');
+		}
+
+		$this->fixtures[] = $fixture;
+
+		return $this;
+	}
+
+}

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -9,6 +9,7 @@ use Cake\TestSuite\TestCase as CoreTestCase;
  */
 abstract class TestCase extends CoreTestCase {
 
+	use FixtureTrait;
 	use TestTrait;
 
 }

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -7,5 +7,5 @@ parameters:
 	ignoreErrors:
 		- '#Variable \$_SESSION in isset\(\) always exists and is not nullable.#'
 		- '#Unreachable statement - code above always terminates.#'
-		- '#Call to an undefined method .+EntityInterface::getDirty\(\).#'
+		- '#Return type .+ of method DecimalType::manyToPHP\(\) should be compatible with .+DecimalType::manyToPHP\(\)#'
 		- '#Variable \$entity in PHPDoc tag \@var does not match any variable in the foreach loop: \$field#'


### PR DESCRIPTION
If we dont' backport https://github.com/cakephp/cakephp/pull/14617 to 3.next
this PR could shim it for 3.9+ apps