### PR TITLE
Make FormShimHelper support extra option keys

### DIFF
--- a/View/Helper/FormShimHelper.php
+++ b/View/Helper/FormShimHelper.php
@@ -162,6 +162,9 @@ class FormShimHelper extends FormHelper {
 			'nestedInput',
 			'templates',
 			'labelOptions',
+			'id',
+			'default',
+			'value',
 		];
 		$diff = array_diff($optionKeys, $supportedKeys);
 		if (!empty($diff)) {


### PR DESCRIPTION
According to the documentation, these should be available in cake3 `control`:

https://book.cakephp.org/3/en/views/helpers/form.html#generating-specific-types-of-controls