### PR TITLE
Change functionality of _checkDeprecatedInputOptions

### DIFF
--- a/View/Helper/FormShimHelper.php
+++ b/View/Helper/FormShimHelper.php
@@ -153,20 +153,16 @@ class FormShimHelper extends FormHelper {
 	 * @return void
 	 */
 	protected function _checkDeprecatedInputOptions($optionKeys) {
-		$supportedKeys = [
-			'type',
-			'label',
-			'options',
-			'error',
-			'empty',
-			'nestedInput',
-			'templates',
-			'labelOptions',
-			'id',
-			'default',
-			'value',
+		$deprecatedKeys = [
+			'after',
+			'before',
+			'between',
+			'div',
+			'errorMessage',
+			'legend',
+			'separator',
 		];
-		$diff = array_diff($optionKeys, $supportedKeys);
+		$diff = array_intersect($optionKeys, $deprecatedKeys);
 		if (!empty($diff)) {
 			$unsupportedKeys = implode(', ', $diff);
 			$message = "FormHelper::control() does not support $unsupportedKeys option(s).";


### PR DESCRIPTION
The reason for this is that valid tags such as `name` or `class` currently fail this check.