### PR TITLE
Test modified entity field methods.

### DIFF
--- a/src/Model/Entity/ModifiedTrait.php
+++ b/src/Model/Entity/ModifiedTrait.php
@@ -17,8 +17,8 @@ trait ModifiedTrait {
 	public function isModified(string $name): bool {
 		$value = $this->get($name);
 		if (
-			array_key_exists($name, $this->_original)
-			&& $this->_original[$name] !== $value
+			!array_key_exists($name, $this->_original)
+			|| $this->_original[$name] !== $value
 		) {
 			return true;
 		}

--- a/src/Model/Entity/ModifiedTrait.php
+++ b/src/Model/Entity/ModifiedTrait.php
@@ -15,6 +15,10 @@ trait ModifiedTrait {
 	 * @return bool
 	 */
 	public function isModified(string $name): bool {
+		if (!$this->isDirty($name)) {
+			return false;
+		}
+
 		$value = $this->get($name);
 		if (
 			!array_key_exists($name, $this->_original)

--- a/src/Model/Entity/ModifiedTrait.php
+++ b/src/Model/Entity/ModifiedTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Shim\Model\Entity;
+
+/**
+ * Trait to get actually changed entity properties.
+ */
+trait ModifiedTrait {
+
+	/**
+	 * Returns if this field actually changed its value, despite dirty state (touched).
+	 *
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function isModified(string $name): bool {
+		$value = $this->get($name);
+		if (
+			array_key_exists($name, $this->_original)
+			&& $this->_original[$name] !== $value
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns all fields that actually changed their value, despite dirty state (touched).
+	 *
+	 * @return array<string>
+	 */
+	public function getModifiedFields(): array {
+		$modified = [];
+
+		$touched = $this->getDirty();
+		foreach ($touched as $field) {
+			if (!$this->isModified($field)) {
+				continue;
+			}
+
+			$modified[] = $field;
+		}
+
+		return $modified;
+	}
+
+}

--- a/tests/TestCase/Model/Entity/EntityModifiedTest.php
+++ b/tests/TestCase/Model/Entity/EntityModifiedTest.php
@@ -11,17 +11,18 @@ class EntityModifiedTest extends TestCase {
 	 * @return void
 	 */
 	public function testGetModifiedFields(): void {
-		$entity = new TestEntity(['foo' => 'foo', 'bar' => 'bar'], ['markClean' => true, 'markNew' => false]);
+		$entity = new TestEntity(['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'], ['markClean' => true, 'markNew' => false]);
 
 		$entity->set('foo', 'foo');
+		$entity->set('bar', 'baaaaaar');
 		$entity->set('foo_bar', 'foo bar');
 
 		$result = $entity->getDirty();
-		$expected = ['foo', 'foo_bar'];
+		$expected = ['foo', 'bar', 'foo_bar'];
 		$this->assertSame($expected, $result);
 
 		$result = $entity->getModifiedFields();
-		$expected = ['foo_bar'];
+		$expected = ['bar', 'foo_bar'];
 		$this->assertSame($expected, $result);
 	}
 

--- a/tests/TestCase/Model/Entity/EntityModifiedTest.php
+++ b/tests/TestCase/Model/Entity/EntityModifiedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Shim\Test\TestCase\Model\Entity;
+
+use Shim\TestSuite\TestCase;
+use TestApp\Model\Entity\TestEntity;
+
+class EntityModifiedTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testGetModifiedFields(): void {
+		$entity = new TestEntity(['foo' => 'foo', 'bar' => 'bar'], ['markClean' => true, 'markNew' => false]);
+
+		$entity->set('foo', 'foo');
+		$entity->set('foo_bar', 'foo bar');
+
+		$result = $entity->getDirty();
+		$expected = ['foo', 'foo_bar'];
+		$this->assertSame($expected, $result);
+
+		$result = $entity->getModifiedFields();
+		$expected = ['foo_bar'];
+		$this->assertSame($expected, $result);
+	}
+
+}

--- a/tests/test_app/src/Model/Entity/TestEntity.php
+++ b/tests/test_app/src/Model/Entity/TestEntity.php
@@ -4,6 +4,7 @@ namespace TestApp\Model\Entity;
 
 use Cake\ORM\Entity;
 use Shim\Model\Entity\GetSetTrait;
+use Shim\Model\Entity\ModifiedTrait;
 use Shim\Model\Entity\ReadTrait;
 
 /**
@@ -14,5 +15,6 @@ class TestEntity extends Entity {
 
 	use GetSetTrait;
 	use ReadTrait;
+	use ModifiedTrait;
 
 }


### PR DESCRIPTION
Tests around https://github.com/cakephp/cakephp/issues/17200 and working around the fallback

It introduces API to handle modified fields:

 - getModifiedFields(): only return dirty fields that actually changed their values


It seems like _originals isnt storing the values as it might be expected to?

Apparently, this piece of Entity core code
```php
            if (
                !array_key_exists($name, $this->_original) &&
                array_key_exists($name, $this->_fields) &&
                $this->_fields[$name] !== $value
            ) {
                $this->_original[$name] = $this->_fields[$name];
            }
```  
Must be changed to
```php
            if (
                !array_key_exists($name, $this->_original) &&
                array_key_exists($name, $this->_fields)
            ) {
                $this->_original[$name] = $this->_fields[$name];
            }
```
then it works.