### PR TITLE
[5.x] Get modified entity field methods.

### DIFF
--- a/src/Model/Entity/ModifiedTrait.php
+++ b/src/Model/Entity/ModifiedTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Shim\Model\Entity;
+
+/**
+ * Trait to get actually changed entity properties.
+ */
+trait ModifiedTrait {
+
+	/**
+	 * Returns if this field actually changed its value, despite dirty state (touched).
+	 *
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function isModified(string $name): bool {
+		if (!$this->isDirty($name)) {
+			return false;
+		}
+
+		$value = $this->get($name);
+		if (
+			!in_array($name, $this->_originalFields, true) ||
+			(
+				array_key_exists($name, $this->_original) &&
+				$this->_original[$name] !== $value
+			)
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns all fields that actually changed their value, despite dirty state (touched).
+	 *
+	 * @return array<string>
+	 */
+	public function getModifiedFields(): array {
+		$modified = [];
+
+		$touched = $this->getDirty();
+		foreach ($touched as $field) {
+			if (!$this->isModified($field)) {
+				continue;
+			}
+
+			$modified[] = $field;
+		}
+
+		return $modified;
+	}
+
+}

--- a/tests/TestCase/Model/Entity/EntityModifiedTest.php
+++ b/tests/TestCase/Model/Entity/EntityModifiedTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Shim\Test\TestCase\Model\Entity;
+
+use Shim\TestSuite\TestCase;
+use TestApp\Model\Entity\TestEntity;
+
+class EntityModifiedTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testGetModifiedFields(): void {
+		$entity = new TestEntity(['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'], ['markClean' => true, 'markNew' => false]);
+
+		$entity->set('foo', 'foo');
+		$entity->set('bar', 'baaaaaar');
+		$entity->set('foo_bar', 'foo bar');
+
+		$result = $entity->getDirty();
+		$expected = ['foo', 'bar', 'foo_bar'];
+		$this->assertEquals($expected, $result);
+
+		$result = $entity->getModifiedFields();
+		$expected = ['bar', 'foo_bar'];
+		$this->assertEquals($expected, $result);
+	}
+
+}

--- a/tests/test_app/src/Model/Entity/TestEntity.php
+++ b/tests/test_app/src/Model/Entity/TestEntity.php
@@ -4,6 +4,7 @@ namespace TestApp\Model\Entity;
 
 use Cake\ORM\Entity;
 use Shim\Model\Entity\GetSetTrait;
+use Shim\Model\Entity\ModifiedTrait;
 use Shim\Model\Entity\ReadTrait;
 
 /**
@@ -14,5 +15,6 @@ class TestEntity extends Entity {
 
 	use GetSetTrait;
 	use ReadTrait;
+	use ModifiedTrait;
 
 }


### PR DESCRIPTION
5.x version of https://github.com/dereuromark/cakephp-shim/pull/107

It introduces API to handle modified fields:

- getModifiedFields(): only return dirty fields that actually changed their values

also trying to count in behavior of proposed PR https://github.com/cakephp/cakephp/pull/17208