### PR TITLE
Fix CakePHP 5.3 deprecations

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -387,12 +387,26 @@ class RequestHandlerComponent extends Component {
 		}
 
 		$viewClass = null;
-		if ($builder->getClass() === null) {
-			$viewClass = App::className($view, 'View', 'View');
+		if (method_exists($builder, 'getClass')) {
+			if ($builder->getClass() === null) {
+				$viewClass = App::className($view, 'View', 'View');
+			}
+		} else {
+			// @codeCoverageIgnoreStart
+			if ($builder->getClassName() === null) {
+				$viewClass = App::className($view, 'View', 'View');
+			}
+			// @codeCoverageIgnoreEnd
 		}
 
 		if ($viewClass) {
-			$builder->setClass($viewClass);
+			if (method_exists($builder, 'setClass')) {
+				$builder->setClass($viewClass);
+			} else {
+				// @codeCoverageIgnoreStart
+				$builder->setClassName($viewClass);
+				// @codeCoverageIgnoreEnd
+			}
 		} else {
 			if (!$this->_renderType) {
 				$builder->setTemplatePath((string)$builder->getTemplatePath() . DIRECTORY_SEPARATOR . $type);

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -387,12 +387,12 @@ class RequestHandlerComponent extends Component {
 		}
 
 		$viewClass = null;
-		if ($builder->getClassName() === null) {
+		if ($builder->getClass() === null) {
 			$viewClass = App::className($view, 'View', 'View');
 		}
 
 		if ($viewClass) {
-			$builder->setClassName($viewClass);
+			$builder->setClass($viewClass);
 		} else {
 			if (!$this->_renderType) {
 				$builder->setTemplatePath((string)$builder->getTemplatePath() . DIRECTORY_SEPARATOR . $type);


### PR DESCRIPTION
## Summary
- Replace deprecated `setClassName()` with `setClass()`
- Replace deprecated `getClassName()` with `getClass()`

## Details
These ViewBuilder methods were deprecated in CakePHP 5.3 and will be removed in CakePHP 6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)