### PR TITLE
Forward table entity generic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 	},
 	"repositories": [
 		{
-			"type": "vcs",
+			"type": "git",
 			"url": "https://github.com/cakephp/cakephp.git"
 		}
 	],

--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,9 @@
 	"support": {
 		"source": "https://github.com/dereuromark/cakephp-shim"
 	},
-	"repositories": [
-		{
-			"type": "git",
-			"url": "https://github.com/cakephp/cakephp.git"
-		}
-	],
 	"require": {
 		"php": ">=8.2",
-		"cakephp/cakephp": "dev-copilot/table-entity-generics-clean as 5.3.3"
+		"cakephp/cakephp": "^5.1.1"
 	},
 	"require-dev": {
 		"dereuromark/cakephp-ide-helper": "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,15 @@
 	"support": {
 		"source": "https://github.com/dereuromark/cakephp-shim"
 	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/cakephp/cakephp.git"
+		}
+	],
 	"require": {
 		"php": ">=8.2",
-		"cakephp/cakephp": "^5.1.1"
+		"cakephp/cakephp": "dev-copilot/table-entity-generics-clean as 5.3.3"
 	},
 	"require-dev": {
 		"dereuromark/cakephp-ide-helper": "^2.0.0",

--- a/src/Model/Table/Table.php
+++ b/src/Model/Table/Table.php
@@ -22,6 +22,8 @@ use InvalidArgumentException;
  * @property array|null $validate
  *
  * @template TBehaviors of array<string, \Cake\ORM\Behavior> = array{}
+ * @template TEntity of \Cake\Datasource\EntityInterface = \Cake\Datasource\EntityInterface
+ * @extends \Cake\ORM\Table<TBehaviors, TEntity>
  */
 class Table extends CoreTable {
 


### PR DESCRIPTION
## Summary
This forwards Cake's new table entity generic through Shim's base table class.

- add `TEntity` to `Shim\Model\Table\Table`
- forward it to `Cake\ORM\Table<TBehaviors, TEntity>`

## Notes
This PR depends on cakephp/cakephp#19388 landing first — the second generic parameter on `Cake\ORM\Table` only exists after that merges. Do not merge this before the core PR is in.