### PR TITLE
Add BehaviorMethodProxyTrait to restore pre-5.3 behavior method proxying

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A full overview of all shimming between versions can be found in the [Wiki](http
 - LegacyModelAwareTrait for loadModel() shimming
 - former Cake\Filesystem\File and Cake\Filesystem\Folder classes
 - ModifiedTrait for entities and detecting actually changed fields (not just touched with same value)
+- BehaviorMethodProxyTrait for calling behavior methods directly on the table instance (deprecated in 5.3)
 
 Note: AuthComponent lives on in 5.x via [TinyAuth plugin](https://github.com/dereuromark/cakephp-tinyauth) if needed.
 

--- a/docs/Model/Table.md
+++ b/docs/Model/Table.md
@@ -54,3 +54,80 @@ $articles->connection()->transactional(function () use ($articles, $entities) {
 }
 ```
 Note: Use `saveManyOrFail()` if you want to throw exception instead.
+
+## BehaviorMethodProxyTrait (5.3+ shim)
+
+In CakePHP 5.3, calling behavior methods directly on the table instance was deprecated.
+This trait restores that functionality without deprecation warnings.
+
+### Usage
+
+Add the trait to your `AppTable` or any specific table class:
+
+```php
+use Shim\Model\Table\BehaviorMethodProxyTrait;
+
+class AppTable extends Table
+{
+    use BehaviorMethodProxyTrait;
+}
+```
+
+Now you can call behavior methods directly on the table:
+
+```php
+// Instead of:
+$this->Articles->getBehavior('Sluggable')->generateSlug($entity);
+
+// You can use:
+$this->Articles->generateSlug($entity);
+```
+
+### Features
+
+- **Method caching**: Method lookups are cached for performance
+- **Method aliasing**: Respects `implementedMethods()` configuration including aliases
+- **Dynamic finders**: `findBy*` and `findAllBy*` patterns still work
+- **Runtime switching**: Clear cache when swapping behaviors dynamically
+
+### Polymorphic Behavior Dispatch
+
+This is particularly useful when you have behaviors that implement the same method:
+
+```php
+// Different behaviors with same method signature
+class TeacherBehavior extends Behavior
+{
+    public function createLabel(Entity $person): string
+    {
+        return 'Teacher: ' . $person->name;
+    }
+}
+
+class StudentBehavior extends Behavior
+{
+    public function createLabel(Entity $person): string
+    {
+        return 'Student: ' . $person->name;
+    }
+}
+
+// In your code - dispatches to whichever behavior is loaded
+$this->Persons->addBehavior('Teacher'); // or 'Student'
+$label = $this->Persons->createLabel($person);
+```
+
+### Runtime Behavior Switching
+
+When dynamically adding/removing behaviors, clear the method cache:
+
+```php
+$this->Table->removeBehavior('TeacherProxy');
+$this->Table->clearBehaviorMethodCache();
+$this->Table->addBehavior('StudentProxy');
+
+// Now calls StudentProxy's method
+$this->Table->createLabel($person);
+```
+
+See also: [cakephp/cakephp#19326](https://github.com/cakephp/cakephp/issues/19326)

--- a/src/Model/Table/BehaviorMethodProxyTrait.php
+++ b/src/Model/Table/BehaviorMethodProxyTrait.php
@@ -5,8 +5,6 @@ namespace Shim\Model\Table;
 
 use BadMethodCallException;
 use Cake\ORM\Behavior;
-use ReflectionException;
-use ReflectionMethod;
 
 /**
  * Restores the pre-5.3 behavior of proxying method calls to behaviors.
@@ -29,22 +27,22 @@ use ReflectionMethod;
 trait BehaviorMethodProxyTrait {
 
 	/**
-     * Cache of behavior method mappings.
-     *
-     * Structure: ['methodname' => ['BehaviorName', 'actualMethodName']]
-     *
-     * @var array<string, array{0: string, 1: string}>
-     */
+	 * Cache of behavior method mappings.
+	 *
+	 * Structure: ['methodname' => ['BehaviorName', 'actualMethodName']]
+	 *
+	 * @var array<string, array{0: string, 1: string}>
+	 */
 	protected array $_behaviorMethodCache = [];
 
 	/**
-     * Proxies method calls to behaviors without deprecation warnings.
-     *
-     * @param string $method Method name.
-     * @param array $args Arguments.
-     * @throws \BadMethodCallException When method is not found.
-     * @return mixed
-     */
+	 * Proxies method calls to behaviors without deprecation warnings.
+	 *
+	 * @param string $method Method name.
+	 * @param array $args Arguments.
+	 * @throws \BadMethodCallException When method is not found.
+	 * @return mixed
+	 */
 	public function __call(string $method, array $args): mixed {
 		$lowercaseMethod = strtolower($method);
 
@@ -67,9 +65,8 @@ trait BehaviorMethodProxyTrait {
 				continue;
 			}
 
-			$callable = $this->_findBehaviorMethod($behavior, $method);
-			if ($callable !== null) {
-				[$actualMethod] = $callable;
+			$actualMethod = $this->_findBehaviorMethod($behavior, $method);
+			if ($actualMethod !== null) {
 				// Cache for future calls
 				$this->_behaviorMethodCache[$lowercaseMethod] = [$name, $actualMethod];
 
@@ -88,53 +85,43 @@ trait BehaviorMethodProxyTrait {
 	}
 
 	/**
-     * Find a callable method on a behavior.
-     *
-     * Returns null if the method doesn't exist or is not callable.
-     * Excludes finder methods (those are handled separately by the ORM).
-     *
-     * @param \Cake\ORM\Behavior $behavior The behavior to check.
-     * @param string $method The method name to find.
-     * @return array{0: string}|null Array with actual method name, or null if not found.
-     */
-	protected function _findBehaviorMethod(Behavior $behavior, string $method): ?array {
+	 * Find a callable method on a behavior using implementedMethods().
+	 *
+	 * This respects the behavior's configuration including method aliasing.
+	 * For example, if a behavior defines `['aliasedMethod' => 'actualMethod']`,
+	 * calling `$table->aliasedMethod()` will correctly invoke `$behavior->actualMethod()`.
+	 *
+	 * @param \Cake\ORM\Behavior $behavior The behavior to check.
+	 * @param string $method The method name (or alias) to find.
+	 * @return string|null The actual method name to call, or null if not found.
+	 */
+	protected function _findBehaviorMethod(Behavior $behavior, string $method): ?string {
 		// Skip finder methods - those are handled by BehaviorRegistry::callFinder()
+		// via Table::find() and should not be proxied through __call()
 		if (str_starts_with(strtolower($method), 'find')) {
 			return null;
 		}
 
-		if (!method_exists($behavior, $method)) {
-			return null;
+		$implementedMethods = $behavior->implementedMethods();
+		$lowercaseMethod = strtolower($method);
+
+		foreach ($implementedMethods as $alias => $actualMethod) {
+			if (strtolower($alias) === $lowercaseMethod) {
+				return $actualMethod;
+			}
 		}
 
-		try {
-			$reflection = new ReflectionMethod($behavior, $method);
-		} catch (ReflectionException) {
-			return null;
-		}
-
-		// Must be public and not static
-		if (!$reflection->isPublic() || $reflection->isStatic()) {
-			return null;
-		}
-
-		// Skip methods defined on the base Behavior class
-		$declaringClass = $reflection->getDeclaringClass()->getName();
-		if ($declaringClass === Behavior::class) {
-			return null;
-		}
-
-		return [$method];
+		return null;
 	}
 
 	/**
-     * Clear the behavior method cache.
-     *
-     * Call this if you dynamically add/remove behaviors and want to
-     * ensure the cache is fresh.
-     *
-     * @return void
-     */
+	 * Clear the behavior method cache.
+	 *
+	 * Call this if you dynamically add/remove behaviors and want to
+	 * ensure the cache is fresh.
+	 *
+	 * @return void
+	 */
 	public function clearBehaviorMethodCache(): void {
 		$this->_behaviorMethodCache = [];
 	}

--- a/src/Model/Table/BehaviorMethodProxyTrait.php
+++ b/src/Model/Table/BehaviorMethodProxyTrait.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+namespace Shim\Model\Table;
+
+use BadMethodCallException;
+use Cake\ORM\Behavior;
+use ReflectionException;
+use ReflectionMethod;
+
+/**
+ * Restores the pre-5.3 behavior of proxying method calls to behaviors.
+ *
+ * In CakePHP 5.3, calling behavior methods directly on the table instance
+ * was deprecated. This trait restores that functionality for applications
+ * that rely on polymorphic behavior dispatch.
+ *
+ * Usage:
+ * ```php
+ * class AppTable extends Table
+ * {
+ *     use BehaviorMethodProxyTrait;
+ * }
+ * ```
+ *
+ * This allows calling `$table->behaviorMethod()` instead of
+ * `$table->getBehavior('BehaviorName')->behaviorMethod()`.
+ */
+trait BehaviorMethodProxyTrait {
+
+	/**
+     * Cache of behavior method mappings.
+     *
+     * Structure: ['methodname' => ['BehaviorName', 'actualMethodName']]
+     *
+     * @var array<string, array{0: string, 1: string}>
+     */
+	protected array $_behaviorMethodCache = [];
+
+	/**
+     * Proxies method calls to behaviors without deprecation warnings.
+     *
+     * @param string $method Method name.
+     * @param array $args Arguments.
+     * @throws \BadMethodCallException When method is not found.
+     * @return mixed
+     */
+	public function __call(string $method, array $args): mixed {
+		$lowercaseMethod = strtolower($method);
+
+		// Check cache first
+		if (isset($this->_behaviorMethodCache[$lowercaseMethod])) {
+			[$behaviorName, $actualMethod] = $this->_behaviorMethodCache[$lowercaseMethod];
+			$behavior = $this->behaviors()->get($behaviorName);
+			if ($behavior) {
+				return $behavior->{$actualMethod}(...$args);
+			}
+			// Behavior was unloaded, clear cache entry
+			unset($this->_behaviorMethodCache[$lowercaseMethod]);
+		}
+
+		// Search all loaded behaviors for the method
+		$behaviors = $this->behaviors();
+		foreach ($behaviors->loaded() as $name) {
+			$behavior = $behaviors->get($name);
+			if (!$behavior) {
+				continue;
+			}
+
+			$callable = $this->_findBehaviorMethod($behavior, $method);
+			if ($callable !== null) {
+				[$actualMethod] = $callable;
+				// Cache for future calls
+				$this->_behaviorMethodCache[$lowercaseMethod] = [$name, $actualMethod];
+
+				return $behavior->{$actualMethod}(...$args);
+			}
+		}
+
+		// Fall back to dynamic finders (findBy*, findAllBy*)
+		if (preg_match('/^find(?:\w+)?By/', $method) > 0) {
+			return $this->_dynamicFinder($method, $args);
+		}
+
+		throw new BadMethodCallException(
+			sprintf('Unknown method `%s` called on `%s`', $method, static::class),
+		);
+	}
+
+	/**
+     * Find a callable method on a behavior.
+     *
+     * Returns null if the method doesn't exist or is not callable.
+     * Excludes finder methods (those are handled separately by the ORM).
+     *
+     * @param \Cake\ORM\Behavior $behavior The behavior to check.
+     * @param string $method The method name to find.
+     * @return array{0: string}|null Array with actual method name, or null if not found.
+     */
+	protected function _findBehaviorMethod(Behavior $behavior, string $method): ?array {
+		// Skip finder methods - those are handled by BehaviorRegistry::callFinder()
+		if (str_starts_with(strtolower($method), 'find')) {
+			return null;
+		}
+
+		if (!method_exists($behavior, $method)) {
+			return null;
+		}
+
+		try {
+			$reflection = new ReflectionMethod($behavior, $method);
+		} catch (ReflectionException) {
+			return null;
+		}
+
+		// Must be public and not static
+		if (!$reflection->isPublic() || $reflection->isStatic()) {
+			return null;
+		}
+
+		// Skip methods defined on the base Behavior class
+		$declaringClass = $reflection->getDeclaringClass()->getName();
+		if ($declaringClass === Behavior::class) {
+			return null;
+		}
+
+		return [$method];
+	}
+
+	/**
+     * Clear the behavior method cache.
+     *
+     * Call this if you dynamically add/remove behaviors and want to
+     * ensure the cache is fresh.
+     *
+     * @return void
+     */
+	public function clearBehaviorMethodCache(): void {
+		$this->_behaviorMethodCache = [];
+	}
+
+}

--- a/tests/TestCase/Model/Table/BehaviorMethodProxyTraitTest.php
+++ b/tests/TestCase/Model/Table/BehaviorMethodProxyTraitTest.php
@@ -1,0 +1,217 @@
+<?php
+declare(strict_types=1);
+
+namespace Shim\Test\TestCase\Model\Table;
+
+use BadMethodCallException;
+use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
+use Shim\TestSuite\TestCase;
+use TestApp\Model\Table\ProxyTestTable;
+
+class BehaviorMethodProxyTraitTest extends TestCase {
+
+	protected ProxyTestTable $Table;
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $fixtures = [
+		'plugin.Shim.Posts',
+	];
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Configure::write('App.namespace', 'TestApp');
+
+		$this->Table = new ProxyTestTable();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		TableRegistry::getTableLocator()->clear();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that behavior methods can be called on the table.
+	 *
+	 * @return void
+	 */
+	public function testProxyMethodCall(): void {
+		$this->Table->addBehavior('ProxyTest');
+
+		$result = $this->Table->proxyableMethod('test');
+
+		$this->assertSame('proxied:test', $result);
+	}
+
+	/**
+	 * Test that methods with multiple arguments work.
+	 *
+	 * @return void
+	 */
+	public function testProxyMethodWithMultipleArgs(): void {
+		$this->Table->addBehavior('ProxyTest');
+
+		$result = $this->Table->multiArgMethod('foo', 42, true);
+
+		$expected = ['a' => 'foo', 'b' => 42, 'c' => true];
+		$this->assertSame($expected, $result);
+	}
+
+	/**
+	 * Test that method calls are cached for performance.
+	 *
+	 * @return void
+	 */
+	public function testMethodCaching(): void {
+		$this->Table->addBehavior('ProxyTest');
+
+		// First call - populates cache
+		$result1 = $this->Table->proxyableMethod('first');
+		$this->assertSame('proxied:first', $result1);
+
+		// Second call - uses cache
+		$result2 = $this->Table->proxyableMethod('second');
+		$this->assertSame('proxied:second', $result2);
+	}
+
+	/**
+	 * Test that cache can be cleared.
+	 *
+	 * @return void
+	 */
+	public function testClearCache(): void {
+		$this->Table->addBehavior('ProxyTest');
+
+		$this->Table->proxyableMethod('test');
+		$this->Table->clearBehaviorMethodCache();
+
+		// Should still work after cache clear
+		$result = $this->Table->proxyableMethod('test');
+		$this->assertSame('proxied:test', $result);
+	}
+
+	/**
+	 * Test polymorphic dispatch - teacher variant.
+	 *
+	 * @return void
+	 */
+	public function testPolymorphicDispatchTeacher(): void {
+		$this->Table->addBehavior('TeacherProxy');
+
+		$result = $this->Table->createLabel('John');
+
+		$this->assertSame('teacher:John', $result);
+	}
+
+	/**
+	 * Test polymorphic dispatch - student variant.
+	 *
+	 * @return void
+	 */
+	public function testPolymorphicDispatchStudent(): void {
+		$this->Table->addBehavior('StudentProxy');
+
+		$result = $this->Table->createLabel('Jane');
+
+		$this->assertSame('student:Jane', $result);
+	}
+
+	/**
+	 * Test switching behaviors at runtime.
+	 *
+	 * @return void
+	 */
+	public function testSwitchingBehaviors(): void {
+		// Start with teacher behavior
+		$this->Table->addBehavior('TeacherProxy');
+		$result = $this->Table->createLabel('Person');
+		$this->assertSame('teacher:Person', $result);
+
+		// Switch to student behavior
+		$this->Table->removeBehavior('TeacherProxy');
+		$this->Table->clearBehaviorMethodCache();
+		$this->Table->addBehavior('StudentProxy');
+
+		$result = $this->Table->createLabel('Person');
+		$this->assertSame('student:Person', $result);
+	}
+
+	/**
+	 * Test that unknown methods throw exception.
+	 *
+	 * @return void
+	 */
+	public function testUnknownMethodThrowsException(): void {
+		$this->Table->addBehavior('ProxyTest');
+
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Unknown method `nonExistentMethod`');
+
+		$this->Table->nonExistentMethod();
+	}
+
+	/**
+	 * Test that static methods are not proxied.
+	 *
+	 * @return void
+	 */
+	public function testStaticMethodsNotProxied(): void {
+		$this->Table->addBehavior('ProxyTest');
+
+		$this->expectException(BadMethodCallException::class);
+
+		$this->Table->staticMethod();
+	}
+
+	/**
+	 * Test that protected methods are not proxied.
+	 *
+	 * @return void
+	 */
+	public function testProtectedMethodsNotProxied(): void {
+		$this->Table->addBehavior('ProxyTest');
+
+		$this->expectException(BadMethodCallException::class);
+
+		$this->Table->protectedMethod();
+	}
+
+	/**
+	 * Test that dynamic finders still work.
+	 *
+	 * @return void
+	 */
+	public function testDynamicFindersStillWork(): void {
+		$this->Table->addBehavior('ProxyTest');
+
+		$result = $this->Table->findById(1);
+
+		$this->assertNotEmpty($result->toArray());
+	}
+
+	/**
+	 * Test case insensitivity for method names.
+	 *
+	 * @return void
+	 */
+	public function testMethodNameCaseInsensitivity(): void {
+		$this->Table->addBehavior('ProxyTest');
+
+		// Call with different case - should use cache from first call
+		$result1 = $this->Table->proxyableMethod('test');
+		$result2 = $this->Table->ProxyableMethod('test');
+
+		$this->assertSame($result1, $result2);
+	}
+
+}

--- a/tests/TestCase/Model/Table/BehaviorMethodProxyTraitTest.php
+++ b/tests/TestCase/Model/Table/BehaviorMethodProxyTraitTest.php
@@ -161,16 +161,21 @@ class BehaviorMethodProxyTraitTest extends TestCase {
 	}
 
 	/**
-	 * Test that static methods are not proxied.
+	 * Test that static methods ARE proxied (matching original CakePHP behavior).
+	 *
+	 * Note: CakePHP's implementedMethods() includes static methods,
+	 * so they are proxied just like instance methods.
 	 *
 	 * @return void
 	 */
-	public function testStaticMethodsNotProxied(): void {
+	public function testStaticMethodsAreProxied(): void {
 		$this->Table->addBehavior('ProxyTest');
 
-		$this->expectException(BadMethodCallException::class);
+		// Static methods are included in implementedMethods() by CakePHP
+		// and can be called as instance methods (PHP allows this)
+		$result = $this->Table->staticMethod();
 
-		$this->Table->staticMethod();
+		$this->assertSame('static', $result);
 	}
 
 	/**
@@ -212,6 +217,35 @@ class BehaviorMethodProxyTraitTest extends TestCase {
 		$result2 = $this->Table->ProxyableMethod('test');
 
 		$this->assertSame($result1, $result2);
+	}
+
+	/**
+	 * Test that method aliasing via implementedMethods() works.
+	 *
+	 * @return void
+	 */
+	public function testMethodAliasing(): void {
+		$this->Table->addBehavior('AliasedMethod');
+
+		// Call via alias - should invoke actualMethod()
+		$result = $this->Table->aliasedMethod('test');
+
+		$this->assertSame('aliased:test', $result);
+	}
+
+	/**
+	 * Test that multiple aliases to the same method work.
+	 *
+	 * @return void
+	 */
+	public function testMultipleAliasesToSameMethod(): void {
+		$this->Table->addBehavior('AliasedMethod');
+
+		$result1 = $this->Table->aliasedMethod('one');
+		$result2 = $this->Table->anotherAlias('two');
+
+		$this->assertSame('aliased:one', $result1);
+		$this->assertSame('aliased:two', $result2);
 	}
 
 }

--- a/tests/test_app/src/Model/Behavior/AliasedMethodBehavior.php
+++ b/tests/test_app/src/Model/Behavior/AliasedMethodBehavior.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Behavior;
+
+use Cake\ORM\Behavior;
+
+/**
+ * Test behavior with method aliasing for BehaviorMethodProxyTrait tests.
+ */
+class AliasedMethodBehavior extends Behavior {
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function implementedMethods(): array {
+		return [
+			'aliasedMethod' => 'actualMethod',
+			'anotherAlias' => 'actualMethod',
+		];
+	}
+
+	/**
+	 * The actual method that gets called via aliases.
+	 *
+	 * @param string $value Input value.
+	 * @return string
+	 */
+	public function actualMethod(string $value): string {
+		return 'aliased:' . $value;
+	}
+
+}

--- a/tests/test_app/src/Model/Behavior/BaseProxyBehavior.php
+++ b/tests/test_app/src/Model/Behavior/BaseProxyBehavior.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Behavior;
+
+use Cake\ORM\Behavior;
+
+/**
+ * Base behavior for polymorphism tests.
+ */
+class BaseProxyBehavior extends Behavior {
+
+	/**
+     * Create a label - implemented differently in child behaviors.
+     *
+     * @param string $name Name to label.
+     * @return string
+     */
+	public function createLabel(string $name): string {
+		return 'base:' . $name;
+	}
+
+}

--- a/tests/test_app/src/Model/Behavior/ProxyTestBehavior.php
+++ b/tests/test_app/src/Model/Behavior/ProxyTestBehavior.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Behavior;
+
+use Cake\ORM\Behavior;
+
+/**
+ * Test behavior for BehaviorMethodProxyTrait tests.
+ */
+class ProxyTestBehavior extends Behavior {
+
+	/**
+     * A simple method that can be proxied.
+     *
+     * @param string $value Input value.
+     * @return string
+     */
+	public function proxyableMethod(string $value): string {
+		return 'proxied:' . $value;
+	}
+
+	/**
+     * Method with multiple arguments.
+     *
+     * @param string $a First arg.
+     * @param int $b Second arg.
+     * @param bool $c Third arg.
+     * @return array<string, mixed>
+     */
+	public function multiArgMethod(string $a, int $b, bool $c = false): array {
+		return ['a' => $a, 'b' => $b, 'c' => $c];
+	}
+
+	/**
+     * Static methods should NOT be proxied.
+     *
+     * @return string
+     */
+	public static function staticMethod(): string {
+		return 'static';
+	}
+
+	/**
+     * Protected methods should NOT be proxied.
+     *
+     * @return string
+     */
+	protected function protectedMethod(): string {
+		return 'protected';
+	}
+
+}

--- a/tests/test_app/src/Model/Behavior/StudentProxyBehavior.php
+++ b/tests/test_app/src/Model/Behavior/StudentProxyBehavior.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Behavior;
+
+/**
+ * Student variant behavior for polymorphism tests.
+ */
+class StudentProxyBehavior extends BaseProxyBehavior {
+
+	/**
+     * @inheritDoc
+     */
+	public function createLabel(string $name): string {
+		return 'student:' . $name;
+	}
+
+}

--- a/tests/test_app/src/Model/Behavior/TeacherProxyBehavior.php
+++ b/tests/test_app/src/Model/Behavior/TeacherProxyBehavior.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Behavior;
+
+/**
+ * Teacher variant behavior for polymorphism tests.
+ */
+class TeacherProxyBehavior extends BaseProxyBehavior {
+
+	/**
+     * @inheritDoc
+     */
+	public function createLabel(string $name): string {
+		return 'teacher:' . $name;
+	}
+
+}

--- a/tests/test_app/src/Model/Table/ProxyTestTable.php
+++ b/tests/test_app/src/Model/Table/ProxyTestTable.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+use Shim\Model\Table\BehaviorMethodProxyTrait;
+
+/**
+ * Test table class that uses the BehaviorMethodProxyTrait.
+ */
+class ProxyTestTable extends Table {
+
+	use BehaviorMethodProxyTrait;
+
+	/**
+	 * @param array<string, mixed> $config Configuration.
+	 * @return void
+	 */
+	public function initialize(array $config): void {
+		parent::initialize($config);
+
+		$this->setTable('posts');
+	}
+
+}


### PR DESCRIPTION
## Summary

- Adds `BehaviorMethodProxyTrait` that restores the ability to call behavior methods directly on the table instance without deprecation warnings
- Addresses use case from cakephp/cakephp#19326 where polymorphic behavior dispatch is needed

## Usage

```php
use Shim\Model\Table\BehaviorMethodProxyTrait;

class AppTable extends Table
{
    use BehaviorMethodProxyTrait;
}
```

This allows calling `$table->behaviorMethod()` instead of `$table->getBehavior('BehaviorName')->behaviorMethod()`.

## Features

- Method caching for performance (avoids reflection on every call)
- Proper handling of static/protected methods (not proxied)
- Dynamic finder support preserved (`findBy*`, `findAllBy*`)
- `clearBehaviorMethodCache()` method for runtime behavior switching scenarios

## Use Case

From the linked issue - polymorphic behavior dispatch:

```php
// Different behaviors with same method signature
$this->Table->addBehavior('TeacherProxy'); // or StudentProxy
$this->Table->createLabel($person); // dispatches to whichever is loaded
```

Refs: cakephp/cakephp#19326