### PR TITLE
Fix SetTrait magic setOrFail off-by-one in argument index

### DIFF
--- a/src/Model/Entity/GetSetTrait.php
+++ b/src/Model/Entity/GetSetTrait.php
@@ -36,7 +36,7 @@ trait GetSetTrait {
 			return $this->getOrFail($property);
 		}
 
-		return $this->setOrFail($property, $arguments[1]);
+		return $this->setOrFail($property, $arguments[0]);
 	}
 
 }

--- a/src/Model/Entity/SetTrait.php
+++ b/src/Model/Entity/SetTrait.php
@@ -44,7 +44,7 @@ trait SetTrait {
 
 		$property = Inflector::underscore($matches[1]);
 
-		$this->setOrFail($property, $arguments[1]);
+		$this->setOrFail($property, $arguments[0]);
 
 		return $this;
 	}

--- a/tests/TestCase/Model/Entity/EntitySetTest.php
+++ b/tests/TestCase/Model/Entity/EntitySetTest.php
@@ -23,12 +23,36 @@ class EntitySetTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testSetOrFailMagic(): void {
+		$entity = new TestEntity();
+		$entity->setFooBarOrFail('Foo Bar');
+
+		$this->assertSame('Foo Bar', $entity->foo_bar);
+		$this->assertSame('Foo Bar', $entity->getFooBarOrFail());
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testSetOrFailMagicInvalid(): void {
 		$entity = new TestEntity();
 
 		$this->expectException(RuntimeException::class);
 
-		$entity->setFooBarOrFail('foo_bar', null);
+		$entity->setFooBarOrFail(null);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSetOrFailMagicMissingArgument(): void {
+		$entity = new TestEntity();
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('param for value not found');
+
+		/** @phpstan-ignore-next-line */
+		$entity->setFooBarOrFail();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The magic `set{PropertyName}OrFail($value)` helpers in `SetTrait::__call` and `GetSetTrait::__call` read the first user argument from `$arguments[1]` instead of `$arguments[0]`.

With the documented one-arg signature this:

1. Raises an `Undefined array key 1` notice;
2. Forwards `null` to `setOrFail()`, which throws `RuntimeException: $prop is null, expected non-null value.`

So `$entity->setFooBarOrFail('value')` *always* fails on the success path — the magic setter is silently broken whenever it is called as documented.

## Why the test suite did not catch it

`EntitySetTest::testSetOrFailMagicInvalid` was calling

~~~ php
$entity->setFooBarOrFail('foo_bar', null);
~~~

with two args. The off-by-one made `$arguments[1] === null` line up with the null-check in `setOrFail()`, so the test's expected exception fired for the wrong reason — and there was no positive-path test covering the documented one-arg call.

## Changes

- `SetTrait::__call`: read `$arguments[0]`.
- `GetSetTrait::__call`: same fix (identical bug, copy-pasted).
- `EntitySetTest::testSetOrFailMagicInvalid`: switch to the documented single-arg signature (`setFooBarOrFail(null)`).
- New `testSetOrFailMagic`: positive-path coverage — sets a value via the magic setter and asserts both raw property access and `getFooBarOrFail()` round-trip.
- New `testSetOrFailMagicMissingArgument`: regression coverage for the existing zero-args guard.

## Verification

- `vendor/bin/phpunit` — 274 tests pass (unrelated `Filesystem/Folder` mkdir warnings/notices were already present on master).
- `vendor/bin/phpstan analyze` — clean.
- `vendor/bin/phpcs` — clean on the changed files.
