### PR TITLE
Fix YearType return type and Table::saveAll bool fold

### DIFF
--- a/src/Database/Type/YearType.php
+++ b/src/Database/Type/YearType.php
@@ -30,7 +30,7 @@ class YearType extends BaseType {
 			return null;
 		}
 
-		return $value;
+		return (int)$value;
 	}
 
 	/**
@@ -62,7 +62,7 @@ class YearType extends BaseType {
 			return null;
 		}
 
-		return $value;
+		return (int)$value;
 	}
 
 	/**

--- a/src/Model/Table/Table.php
+++ b/src/Model/Table/Table.php
@@ -420,10 +420,12 @@ class Table extends CoreTable {
 	public function saveAll(array $entities, array $options = []): bool {
 		$success = true;
 		foreach ($entities as $entity) {
-			$success = $success & (bool)$this->save($entity, $options);
+			if ($this->save($entity, $options) === false) {
+				$success = false;
+			}
 		}
 
-		return (bool)$success;
+		return $success;
 	}
 
 	/**

--- a/tests/TestCase/Database/Type/YearTypeTest.php
+++ b/tests/TestCase/Database/Type/YearTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Shim\Test\TestCase\Database\Type;
 
+use Cake\Database\Driver;
 use Cake\Database\TypeFactory;
 use Cake\ORM\TableRegistry;
 use Cake\View\Helper\FormHelper;
@@ -55,6 +56,24 @@ class YearTypeTest extends TestCase {
 
 		$record = $this->Table->get($entity->id);
 		$this->assertSame(2015, $record->year_of_birth);
+	}
+
+	/**
+	 * Regression: `toDatabase()` and `marshal()` must return `int` (not the
+	 * unmodified numeric string). Without the cast the declared `?int` return
+	 * type is violated under strict_types.
+	 *
+	 * @return void
+	 */
+	public function testToDatabaseAndMarshalReturnInt(): void {
+		$type = new YearType('year');
+		$driver = $this->getMockBuilder(Driver::class)->disableOriginalConstructor()->getMock();
+
+		$this->assertSame(2024, $type->toDatabase('2024', $driver));
+		$this->assertSame(2024, $type->marshal('2024'));
+		$this->assertSame(2024, $type->marshal(['year' => '2024']));
+		$this->assertNull($type->toDatabase(null, $driver));
+		$this->assertNull($type->marshal(''));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Two correctness fixes

### YearType return type

`src/Database/Type/YearType.php` — `toDatabase()` and `marshal()` both declare `: ?int` but return `$value` unmodified after passing the null check. With the typical numeric-string input (e.g. `"2024"`) this violates the declared contract under `declare(strict_types=1)`. The sibling `toPHP()` already does the right thing (`return (int)$value`); these two now match. Added a regression test exercising both methods with string, array (`['year' => '2024']`), null, and empty-string inputs.

### Table::saveAll bool fold

`src/Model/Table/Table.php` — `saveAll()` used a bitwise `&` to fold per-row save results:

```php
$success = $success & (bool)$this->save($entity, $options);
```

The `&` operator coerces both operands to int, so after the first iteration `$success` is `0` or `1`, not a bool. The outer `(bool)$success` cast in the return statement papered over it but PHPStan-strict and any caller using `=== true` were misled. Replaced with an early-out pattern that keeps the accumulator a proper bool throughout.

The existing `testSaveAll` already covers both true and false outcomes and continues to pass.

## Verification

- `vendor/bin/phpunit` — 275 tests, 943 assertions, all green (the 1 warning + 48 notices are unrelated `Filesystem/Folder` mkdir noise that was already on master).
- `vendor/bin/phpstan analyze` — clean.
- `vendor/bin/phpcs` — clean.
