### PR TITLE
Polish: drop misleading deprecation tags, harden defensive paths, modernize PHP 8 idioms

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -223,7 +223,6 @@ class RequestHandlerComponent extends Component {
 	 *
 	 * Returns true if the client accepts XML.
 	 *
-	 * @deprecated 4.4.0 Use ContentTypeNegotiation::prefersChoice() or Controller::getViewClasses() instead.
 	 * @param array<string>|string|null $type Can be null (or no parameter), a string type name, or an
 	 *   array of types
 	 * @return array|string|bool|null If null or no parameter is passed, returns an array of content
@@ -300,7 +299,6 @@ class RequestHandlerComponent extends Component {
 	 * if provided, and secondarily by the list of content-types provided in
 	 * HTTP_ACCEPT.
 	 *
-	 * @deprecated 4.4.0 Use Controller::getViewClasses() instead.
 	 * @param array<string>|string|null $type An optional array of 'friendly' content-type names, i.e.
 	 *   'html', 'xml', 'js', etc.
 	 * @return string|bool|null If $type is null or not provided, the first content-type in the

--- a/src/Datasource/LegacyModelAwareTrait.php
+++ b/src/Datasource/LegacyModelAwareTrait.php
@@ -68,7 +68,13 @@ trait LegacyModelAwareTrait {
 			$modelClass = $alias;
 		}
 
-		$factory = $this->_modelFactories[$modelType] ?? FactoryLocator::get($modelType);
+		// `_modelFactories` was the public-ish array on `ModelAwareTrait` in 4.x.
+		// The trait was removed in 5.x, so the property only exists on consumers
+		// that explicitly redeclare it. Guard the lookup to avoid an undeclared
+		// dynamic-property warning under PHP 8.2+ when the consumer hasn't.
+		$factory = (property_exists($this, '_modelFactories') && isset($this->_modelFactories[$modelType]))
+			? $this->_modelFactories[$modelType]
+			: FactoryLocator::get($modelType);
 		if ($factory instanceof LocatorInterface) {
 			$instance = $factory->get($modelClass, $options);
 		} else {

--- a/src/Deprecations.php
+++ b/src/Deprecations.php
@@ -1,10 +1,24 @@
 <?php
+declare(strict_types=1);
 
 namespace Shim;
 
 use Cake\Core\Configure;
 
 class Deprecations {
+
+	/**
+	 * Levels accepted by `trigger_error()` for the `error_type` argument.
+	 * Anything else raises a `ValueError` on PHP 8+.
+	 *
+	 * @var array<int>
+	 */
+	protected const VALID_TRIGGER_LEVELS = [
+		E_USER_NOTICE,
+		E_USER_WARNING,
+		E_USER_DEPRECATED,
+		E_USER_ERROR,
+	];
 
 	/**
 	 * @param string $type
@@ -28,6 +42,9 @@ class Deprecations {
 	 */
 	public static function error(string $message): void {
 		$type = Configure::read('Shim.deprecationType') ?: E_USER_DEPRECATED;
+		if (!in_array($type, static::VALID_TRIGGER_LEVELS, true)) {
+			$type = E_USER_DEPRECATED;
+		}
 
 		trigger_error($message, $type);
 	}

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -289,7 +289,7 @@ class Folder {
 	 * @return bool true if windows path, false otherwise
 	 */
 	public static function isWindowsPath(string $path): bool {
-		return preg_match('/^[A-Z]:\\\\/i', $path) || substr($path, 0, 2) === '\\\\';
+		return (bool)preg_match('/^[A-Z]:\\\\/i', $path) || str_starts_with($path, '\\\\');
 	}
 
 	/**
@@ -304,8 +304,8 @@ class Folder {
 		}
 
 		return $path[0] === '/' ||
-			preg_match('/^[A-Z]:\\\\/i', $path) ||
-			substr($path, 0, 2) === '\\\\' ||
+			(bool)preg_match('/^[A-Z]:\\\\/i', $path) ||
+			str_starts_with($path, '\\\\') ||
 			static::isRegisteredStreamWrapper($path);
 	}
 
@@ -316,7 +316,7 @@ class Folder {
 	 * @return bool True if path is registered stream wrapper.
 	 */
 	public static function isRegisteredStreamWrapper(string $path): bool {
-		return preg_match('/^[^:\/]+?(?=:\/\/)/', $path, $matches) &&
+		return (bool)preg_match('/^[^:\/]+?(?=:\/\/)/', $path, $matches) &&
 			in_array($matches[0], stream_get_wrappers(), true);
 	}
 

--- a/src/Model/Table/Table.php
+++ b/src/Model/Table/Table.php
@@ -274,10 +274,9 @@ class Table extends CoreTable {
 	public function record(mixed $id, array $options = []): mixed {
 		try {
 			return $this->get($id, ...$options);
-		} catch (RecordNotFoundException $e) {
+		} catch (RecordNotFoundException) {
+			return null;
 		}
-
-		return null;
 	}
 
 	/**
@@ -457,14 +456,11 @@ class Table extends CoreTable {
 	 * - 'strict': Throw exception instead of returning false. Defaults to false.
 	 *
 	 * @param \Cake\Datasource\EntityInterface $entity The entity to remove.
-	 * @param \ArrayAccess|array<string, mixed> $options The options for the delete.
+	 * @param array<string, mixed> $options The options for the delete.
 	 * @throws \InvalidArgumentException
 	 * @return bool success
 	 */
-	public function delete(EntityInterface $entity, $options = []): bool {
-		if (!is_array($options)) {
-			throw new InvalidArgumentException('Invalid options input.');
-		}
+	public function delete(EntityInterface $entity, array $options = []): bool {
 		$options += ['strict' => false];
 
 		$result = parent::delete($entity, $options);

--- a/src/TestSuite/TestTrait.php
+++ b/src/TestSuite/TestTrait.php
@@ -82,13 +82,13 @@ trait TestTrait {
 	 *   $user->cryptPassword('passwordToCrypt');
 	 * (assuming the method was directly publicly accessible
 	 *
-	 * @param object &$object Instantiated object that we will run method on.
+	 * @param object $object Instantiated object that we will run method on.
 	 * @param string $methodName Method name to call.
 	 * @param array $parameters Array of parameters to pass into method.
 	 *
 	 * @return mixed Method return.
 	 */
-	protected function invokeMethod(object &$object, string $methodName, array $parameters = []): mixed {
+	protected function invokeMethod(object $object, string $methodName, array $parameters = []): mixed {
 		$reflection = new ReflectionClass(get_class($object));
 		$method = $reflection->getMethod($methodName);
 
@@ -104,12 +104,12 @@ trait TestTrait {
 	 *   $object->_foo
 	 * (assuming the property was directly publicly accessible)
 	 *
-	 * @param object &$object Instantiated object that we want the property off.
+	 * @param object $object Instantiated object that we want the property off.
 	 * @param string $name Property name to fetch.
 	 *
 	 * @return mixed Property value.
 	 */
-	protected function invokeProperty(object &$object, string $name): mixed {
+	protected function invokeProperty(object $object, string $name): mixed {
 		$reflection = new ReflectionClass(get_class($object));
 		if (!$reflection->hasProperty($name)) {
 			return null;

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -278,9 +278,7 @@ class DateTimeWidget extends BasicWidget {
 						$dateArray['second'] = '0';
 					}
 					if (!empty($value['meridian'])) {
-						/** @var string $meridian */
-						$meridian = $dateArray['meridian'];
-						$isAm = strtolower($meridian) === 'am';
+						$isAm = strtolower((string)$value['meridian']) === 'am';
 						$dateArray['hour'] = $isAm ? (int)$dateArray['hour'] : (int)$dateArray['hour'] + 12;
 						$dateArray['hour'] = str_pad((string)$dateArray['hour'], 2, '0', STR_PAD_LEFT);
 					}

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -41,7 +41,7 @@ class EntityAnnotatorTest extends TestCase {
 	 *
 	 * @return mixed Method return.
 	 */
-	protected function invokeMethod(object &$object, string $methodName, array $parameters = []): mixed {
+	protected function invokeMethod(object $object, string $methodName, array $parameters = []): mixed {
 		$reflection = new ReflectionClass(get_class($object));
 		$method = $reflection->getMethod($methodName);
 


### PR DESCRIPTION
## Summary

Batch of small correctness / hygiene fixes after the previous YearType + saveAll PR.

### Drop the misleading deprecation tags on `RequestHandlerComponent::accepts()` / `prefers()`

Both methods carried `deprecated 4.4.0` doc tags copied verbatim from the upstream core they were extracted from. The whole purpose of this shim is to re-introduce the pre-4.4 RequestHandlerComponent surface for consumers who have not yet migrated to `ContentTypeNegotiation::prefersChoice()` / `Controller::getViewClasses()`. Flagging the methods deprecated *inside the shim* is misleading: the shim's job is to keep them around. Removed.

### DateTimeWidget meridian: read AM/PM from the same place the conditional checked

`_deconstructDate()` was checking `!empty($value['meridian'])` but reading the AM/PM character from `$dateArray['meridian']` (the str-padded copy). For typical inputs (`'am'`/`'pm'`) it happened to round-trip cleanly through `str_pad`, but the decoupling between conditional source and value source has been a historical bug source. Read from `$value['meridian']` for both.

### `Table::record()`: PHP 8 capture-omit `catch`

The empty `catch (RecordNotFoundException $e) {}` body was flagged by PSR2R / phpcs. Switch to `catch (RecordNotFoundException) { return null; }` (PHP 8.0+).

### `Table::delete()`: restore the parent's typed `array $options`

The override widened the parent's `array $options` to bare `$options` and then re-checked `is_array()` at runtime. Under `declare(strict_types=1)` the check is dead — callers already type-hint `array`, and PHPStan-strict / consumers reading the signature were misled. Restore the `array` hint, drop the dead check.

### `LegacyModelAwareTrait::loadModel()`: defensive `_modelFactories` lookup

The trait read `$this->_modelFactories[$modelType]` unconditionally. That property lived on 4.x's `ModelAwareTrait`, which was removed in 5.x — consumers that don't redeclare it hit an undeclared-dynamic-property warning under PHP 8.2+. Guard with `property_exists()` so the lookup falls back cleanly to `FactoryLocator::get()`.

### `Folder::isAbsolute()` / `isWindowsPath()` / `isRegisteredStreamWrapper()`: explicit bool casts and `str_starts_with`

These returned `int|false` from `preg_match()` directly into a `: bool` signature, with the actual bool result coming from short-circuiting `||`. Cast `(bool)` explicitly so the contract holds under stricter PHPStan rules. Also swap `substr($path, 0, 2) === '\\\\'` for `str_starts_with()`.

### `Deprecations.php`: strict_types and a `trigger_error` level guard

- Add `declare(strict_types=1)` to match the rest of `src/`.
- `trigger_error()` only accepts `E_USER_NOTICE` / `WARNING` / `DEPRECATED` / `ERROR`; passing anything else raises `ValueError` on PHP 8+. A misconfigured app that sets `Configure::write('Shim.deprecationType', E_NOTICE)` would crash the shim's own deprecation pathway. Validate against an allow-list and fall back to `E_USER_DEPRECATED`.

### `TestSuite\TestTrait`: drop redundant `&` on object parameters

`invokeMethod(object &$object, ...)` and `invokeProperty(object &$object, ...)` had a leftover `&` reference. Objects are passed by handle in PHP, the reference does nothing. `EntityAnnotatorTest` overrides `invokeMethod()` with the same shape and is updated to match the new signature.

## Verification

- `vendor/bin/phpunit` — 275 tests, 943 assertions, all green (1 warning + 48 notices are unrelated `Filesystem/Folder` mkdir noise that pre-dates this PR).
- `vendor/bin/phpstan analyze` — clean.
- `vendor/bin/phpcs` — clean.
