### PR TITLE
Add PhpEngine cache shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A full overview of all shimming between versions can be found in the [Wiki](http
 - LegacyModelAwareTrait for loadModel() shimming
 - former Cake\Filesystem\File and Cake\Filesystem\Folder classes
 - ModifiedTrait for entities and detecting actually changed fields (not just touched with same value)
+- CakePHP 6.x `PhpEngine` cache backend for OPcache-backed file caches
 
 Note: AuthComponent lives on in 5.x via [TinyAuth plugin](https://github.com/dereuromark/cakephp-tinyauth) if needed.
 

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
 		"cakephp/cakephp": "^5.1.1"
 	},
 	"require-dev": {
+		"brick/varexporter": "^0.7.0",
 		"dereuromark/cakephp-ide-helper": "^2.0.0",
 		"fig-r/psr2r-sniffer": "dev-master",
 		"phpunit/phpunit": "^11.5 || ^12.1 || ^13.0"

--- a/docs/Cache/PhpEngine.md
+++ b/docs/Cache/PhpEngine.md
@@ -32,3 +32,23 @@ Cache::setConfig('php_cache', [
 This engine is best suited for mostly static caches such as metadata, routes, configuration, or attribute discovery.
 
 It is not suited for atomic `increment()` / `decrement()` operations.
+
+## Benchmark
+
+A small local benchmark script is available to compare CakePHP `File` and shimmed `PhpEngine` caches across several payload types:
+
+```bash
+php tests/benchmark/cache_engine_benchmark.php
+```
+
+Optional arguments:
+
+```bash
+php tests/benchmark/cache_engine_benchmark.php --writes=200 --reads=1000
+```
+
+For a more realistic `PhpEngine` read comparison in CLI, enable OPcache for the run:
+
+```bash
+php -d opcache.enable_cli=1 tests/benchmark/cache_engine_benchmark.php
+```

--- a/docs/Cache/PhpEngine.md
+++ b/docs/Cache/PhpEngine.md
@@ -1,0 +1,34 @@
+# Cache PhpEngine
+
+Backports CakePHP 6.x `PhpEngine` to CakePHP 5 applications through this shim plugin.
+
+It stores cache entries as executable PHP files and uses OPcache for faster reads than the regular file cache engine.
+
+## Installation
+
+The shim ships the class, but the exporter dependency stays optional.
+If you want to use this engine in an app, add:
+
+```bash
+composer require brick/varexporter
+```
+
+## Usage
+
+Configure a cache with the shimmed engine class:
+
+```php
+use Cake\Cache\Cache;
+use Shim\Cache\Engine\PhpEngine;
+
+Cache::setConfig('php_cache', [
+	'className' => PhpEngine::class,
+	'path' => CACHE . 'php/',
+	'prefix' => 'myapp_',
+	'duration' => '+1 year',
+]);
+```
+
+This engine is best suited for mostly static caches such as metadata, routes, configuration, or attribute discovery.
+
+It is not suited for atomic `increment()` / `decrement()` operations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,9 @@ Database
 - [Year type](Database/Year.md)
 - [Array type](Database/Array.md)
 
+Cache
+- [PhpEngine](Cache/PhpEngine.md)
+
 Datasource
 - [LegacyModelAwareTrait](Datasource/LegacyModelAwareTrait.md)
 - [NumericPaginator](Datasource/NumericPaginator.md)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,3 +12,6 @@ parameters:
 		- identifier: missingType.iterableValue
 		- identifier: missingType.generics
 		- identifier: trait.unused
+		-
+			message: '#Call to function method_exists\(\) with \$this\(Shim\\Cache\\Engine\\PhpEngine\) and ''getEventManager'' will always evaluate to true\.#'
+			path: src/Cache/Engine/PhpEngine.php

--- a/src/Cache/Engine/PhpEngine.php
+++ b/src/Cache/Engine/PhpEngine.php
@@ -417,12 +417,6 @@ class PhpEngine extends CacheEngine {
 	 * @return void
 	 */
 	protected function _dispatchEventCompat(string $name, array $data = []): void {
-		if (is_callable([$this, 'dispatchEvent'])) {
-			$this->dispatchEvent($name, $data);
-
-			return;
-		}
-
 		$this->getEventManager()->dispatch(new Event($name, $this, $data));
 	}
 

--- a/src/Cache/Engine/PhpEngine.php
+++ b/src/Cache/Engine/PhpEngine.php
@@ -14,6 +14,7 @@ use Cake\Cache\Event\CacheBeforeGetEvent;
 use Cake\Cache\Event\CacheBeforeSetEvent;
 use Cake\Cache\Event\CacheClearedEvent;
 use Cake\Cache\Event\CacheGroupClearEvent;
+use Cake\Event\Event;
 use DateInterval;
 use LogicException;
 use SplFileInfo;
@@ -101,7 +102,7 @@ class PhpEngine extends CacheEngine {
 		$key = $this->_key($key);
 
 		$this->_eventClass = CacheBeforeSetEvent::class;
-		$this->dispatchEvent(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $duration]);
+		$this->_dispatchEventCompat(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $duration]);
 
 		$this->_eventClass = CacheAfterSetEvent::class;
 		$path = $this->_path($key);
@@ -115,7 +116,7 @@ class PhpEngine extends CacheEngine {
 				$e->getMessage(),
 			));
 
-			$this->dispatchEvent(CacheAfterSetEvent::NAME, [
+			$this->_dispatchEventCompat(CacheAfterSetEvent::NAME, [
 				'key' => $key,
 				'value' => $value,
 				'success' => false,
@@ -134,7 +135,7 @@ class PhpEngine extends CacheEngine {
 
 		$success = $this->_writeFile($path, $contents);
 
-		$this->dispatchEvent(CacheAfterSetEvent::NAME, [
+		$this->_dispatchEventCompat(CacheAfterSetEvent::NAME, [
 			'key' => $key,
 			'value' => $value,
 			'success' => $success,
@@ -153,18 +154,18 @@ class PhpEngine extends CacheEngine {
 		$key = $this->_key($key);
 
 		$this->_eventClass = CacheBeforeGetEvent::class;
-		$this->dispatchEvent(CacheBeforeGetEvent::NAME, ['key' => $key, 'default' => $default]);
+		$this->_dispatchEventCompat(CacheBeforeGetEvent::NAME, ['key' => $key, 'default' => $default]);
 
 		$this->_eventClass = CacheAfterGetEvent::class;
 		if (!$this->_init) {
-			$this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+			$this->_dispatchEventCompat(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
 
 			return $default;
 		}
 
 		$path = $this->_path($key);
 		if (!is_file($path)) {
-			$this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+			$this->_dispatchEventCompat(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
 
 			return $default;
 		}
@@ -179,7 +180,7 @@ class PhpEngine extends CacheEngine {
 			));
 			$this->_deleteFile($path);
 
-			$this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+			$this->_dispatchEventCompat(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
 
 			return $default;
 		}
@@ -187,12 +188,12 @@ class PhpEngine extends CacheEngine {
 		if ($value === null) {
 			$this->_deleteFile($path);
 
-			$this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+			$this->_dispatchEventCompat(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
 
 			return $default;
 		}
 
-		$this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => $value, 'success' => true]);
+		$this->_dispatchEventCompat(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => $value, 'success' => true]);
 
 		return $value;
 	}
@@ -205,18 +206,18 @@ class PhpEngine extends CacheEngine {
 		$key = $this->_key($key);
 
 		$this->_eventClass = CacheBeforeDeleteEvent::class;
-		$this->dispatchEvent(CacheBeforeDeleteEvent::NAME, ['key' => $key]);
+		$this->_dispatchEventCompat(CacheBeforeDeleteEvent::NAME, ['key' => $key]);
 
 		$this->_eventClass = CacheAfterDeleteEvent::class;
 		if (!$this->_init) {
-			$this->dispatchEvent(CacheAfterDeleteEvent::NAME, ['key' => $key, 'success' => false]);
+			$this->_dispatchEventCompat(CacheAfterDeleteEvent::NAME, ['key' => $key, 'success' => false]);
 
 			return false;
 		}
 
 		$success = $this->_deleteFile($this->_path($key));
 
-		$this->dispatchEvent(CacheAfterDeleteEvent::NAME, ['key' => $key, 'success' => $success]);
+		$this->_dispatchEventCompat(CacheAfterDeleteEvent::NAME, ['key' => $key, 'success' => $success]);
 
 		return $success;
 	}
@@ -232,7 +233,7 @@ class PhpEngine extends CacheEngine {
 		$this->_clearDirectory($this->_config['path']);
 
 		$this->_eventClass = CacheClearedEvent::class;
-		$this->dispatchEvent(CacheClearedEvent::NAME);
+		$this->_dispatchEventCompat(CacheClearedEvent::NAME);
 
 		return true;
 	}
@@ -266,7 +267,7 @@ class PhpEngine extends CacheEngine {
 		}
 
 		$this->_eventClass = CacheGroupClearEvent::class;
-		$this->dispatchEvent(CacheGroupClearEvent::NAME, ['group' => $group]);
+		$this->_dispatchEventCompat(CacheGroupClearEvent::NAME, ['group' => $group]);
 
 		return true;
 	}
@@ -406,6 +407,23 @@ class PhpEngine extends CacheEngine {
 		}
 
 		return $success;
+	}
+
+	/**
+	 * Dispatch cache events across CakePHP 5.x minors.
+	 *
+	 * @param string $name Event name.
+	 * @param array<string, mixed> $data Event data.
+	 * @return void
+	 */
+	protected function _dispatchEventCompat(string $name, array $data = []): void {
+		if (is_callable([$this, 'dispatchEvent'])) {
+			$this->dispatchEvent($name, $data);
+
+			return;
+		}
+
+		$this->getEventManager()->dispatch(new Event($name, $this, $data));
 	}
 
 	/**

--- a/src/Cache/Engine/PhpEngine.php
+++ b/src/Cache/Engine/PhpEngine.php
@@ -6,14 +6,6 @@ namespace Shim\Cache\Engine;
 
 use Brick\VarExporter\VarExporter;
 use Cake\Cache\CacheEngine;
-use Cake\Cache\Event\CacheAfterDeleteEvent;
-use Cake\Cache\Event\CacheAfterGetEvent;
-use Cake\Cache\Event\CacheAfterSetEvent;
-use Cake\Cache\Event\CacheBeforeDeleteEvent;
-use Cake\Cache\Event\CacheBeforeGetEvent;
-use Cake\Cache\Event\CacheBeforeSetEvent;
-use Cake\Cache\Event\CacheClearedEvent;
-use Cake\Cache\Event\CacheGroupClearEvent;
 use Cake\Event\Event;
 use DateInterval;
 use LogicException;
@@ -29,6 +21,46 @@ use Throwable;
  * @extends \Cake\Cache\CacheEngine<\Shim\Cache\Engine\PhpEngine>
  */
 class PhpEngine extends CacheEngine {
+
+	/**
+	 * @var string
+	 */
+	protected const EVENT_BEFORE_SET = 'Cache.beforeSet';
+
+	/**
+	 * @var string
+	 */
+	protected const EVENT_AFTER_SET = 'Cache.afterSet';
+
+	/**
+	 * @var string
+	 */
+	protected const EVENT_BEFORE_GET = 'Cache.beforeGet';
+
+	/**
+	 * @var string
+	 */
+	protected const EVENT_AFTER_GET = 'Cache.afterGet';
+
+	/**
+	 * @var string
+	 */
+	protected const EVENT_BEFORE_DELETE = 'Cache.beforeDelete';
+
+	/**
+	 * @var string
+	 */
+	protected const EVENT_AFTER_DELETE = 'Cache.afterDelete';
+
+	/**
+	 * @var string
+	 */
+	protected const EVENT_CLEARED = 'Cache.cleared';
+
+	/**
+	 * @var string
+	 */
+	protected const EVENT_CLEARED_GROUP = 'Cache.clearedGroup';
 
 	/**
 	 * The default config used unless overridden by runtime configuration
@@ -101,10 +133,8 @@ class PhpEngine extends CacheEngine {
 		$duration = $this->duration($ttl);
 		$key = $this->_key($key);
 
-		$this->_eventClass = CacheBeforeSetEvent::class;
-		$this->_dispatchEventCompat(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $duration]);
+		$this->_dispatchEventCompat(static::EVENT_BEFORE_SET, ['key' => $key, 'value' => $value, 'ttl' => $duration]);
 
-		$this->_eventClass = CacheAfterSetEvent::class;
 		$path = $this->_path($key);
 
 		try {
@@ -116,7 +146,7 @@ class PhpEngine extends CacheEngine {
 				$e->getMessage(),
 			));
 
-			$this->_dispatchEventCompat(CacheAfterSetEvent::NAME, [
+			$this->_dispatchEventCompat(static::EVENT_AFTER_SET, [
 				'key' => $key,
 				'value' => $value,
 				'success' => false,
@@ -135,7 +165,7 @@ class PhpEngine extends CacheEngine {
 
 		$success = $this->_writeFile($path, $contents);
 
-		$this->_dispatchEventCompat(CacheAfterSetEvent::NAME, [
+		$this->_dispatchEventCompat(static::EVENT_AFTER_SET, [
 			'key' => $key,
 			'value' => $value,
 			'success' => $success,
@@ -153,19 +183,17 @@ class PhpEngine extends CacheEngine {
 	public function get(string $key, mixed $default = null): mixed {
 		$key = $this->_key($key);
 
-		$this->_eventClass = CacheBeforeGetEvent::class;
-		$this->_dispatchEventCompat(CacheBeforeGetEvent::NAME, ['key' => $key, 'default' => $default]);
+		$this->_dispatchEventCompat(static::EVENT_BEFORE_GET, ['key' => $key, 'default' => $default]);
 
-		$this->_eventClass = CacheAfterGetEvent::class;
 		if (!$this->_init) {
-			$this->_dispatchEventCompat(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+			$this->_dispatchEventCompat(static::EVENT_AFTER_GET, ['key' => $key, 'value' => null, 'success' => false]);
 
 			return $default;
 		}
 
 		$path = $this->_path($key);
 		if (!is_file($path)) {
-			$this->_dispatchEventCompat(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+			$this->_dispatchEventCompat(static::EVENT_AFTER_GET, ['key' => $key, 'value' => null, 'success' => false]);
 
 			return $default;
 		}
@@ -180,7 +208,7 @@ class PhpEngine extends CacheEngine {
 			));
 			$this->_deleteFile($path);
 
-			$this->_dispatchEventCompat(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+			$this->_dispatchEventCompat(static::EVENT_AFTER_GET, ['key' => $key, 'value' => null, 'success' => false]);
 
 			return $default;
 		}
@@ -188,12 +216,12 @@ class PhpEngine extends CacheEngine {
 		if ($value === null) {
 			$this->_deleteFile($path);
 
-			$this->_dispatchEventCompat(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+			$this->_dispatchEventCompat(static::EVENT_AFTER_GET, ['key' => $key, 'value' => null, 'success' => false]);
 
 			return $default;
 		}
 
-		$this->_dispatchEventCompat(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => $value, 'success' => true]);
+		$this->_dispatchEventCompat(static::EVENT_AFTER_GET, ['key' => $key, 'value' => $value, 'success' => true]);
 
 		return $value;
 	}
@@ -205,19 +233,17 @@ class PhpEngine extends CacheEngine {
 	public function delete(string $key): bool {
 		$key = $this->_key($key);
 
-		$this->_eventClass = CacheBeforeDeleteEvent::class;
-		$this->_dispatchEventCompat(CacheBeforeDeleteEvent::NAME, ['key' => $key]);
+		$this->_dispatchEventCompat(static::EVENT_BEFORE_DELETE, ['key' => $key]);
 
-		$this->_eventClass = CacheAfterDeleteEvent::class;
 		if (!$this->_init) {
-			$this->_dispatchEventCompat(CacheAfterDeleteEvent::NAME, ['key' => $key, 'success' => false]);
+			$this->_dispatchEventCompat(static::EVENT_AFTER_DELETE, ['key' => $key, 'success' => false]);
 
 			return false;
 		}
 
 		$success = $this->_deleteFile($this->_path($key));
 
-		$this->_dispatchEventCompat(CacheAfterDeleteEvent::NAME, ['key' => $key, 'success' => $success]);
+		$this->_dispatchEventCompat(static::EVENT_AFTER_DELETE, ['key' => $key, 'success' => $success]);
 
 		return $success;
 	}
@@ -231,9 +257,7 @@ class PhpEngine extends CacheEngine {
 		}
 
 		$this->_clearDirectory($this->_config['path']);
-
-		$this->_eventClass = CacheClearedEvent::class;
-		$this->_dispatchEventCompat(CacheClearedEvent::NAME);
+		$this->_dispatchEventCompat(static::EVENT_CLEARED);
 
 		return true;
 	}
@@ -265,9 +289,7 @@ class PhpEngine extends CacheEngine {
 		if (is_dir($path)) {
 			$this->_clearDirectory($path);
 		}
-
-		$this->_eventClass = CacheGroupClearEvent::class;
-		$this->_dispatchEventCompat(CacheGroupClearEvent::NAME, ['group' => $group]);
+		$this->_dispatchEventCompat(static::EVENT_CLEARED_GROUP, ['group' => $group]);
 
 		return true;
 	}

--- a/src/Cache/Engine/PhpEngine.php
+++ b/src/Cache/Engine/PhpEngine.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shim\Cache\Engine;
+
+use Brick\VarExporter\VarExporter;
+use Cake\Cache\CacheEngine;
+use Cake\Cache\Event\CacheAfterDeleteEvent;
+use Cake\Cache\Event\CacheAfterGetEvent;
+use Cake\Cache\Event\CacheAfterSetEvent;
+use Cake\Cache\Event\CacheBeforeDeleteEvent;
+use Cake\Cache\Event\CacheBeforeGetEvent;
+use Cake\Cache\Event\CacheBeforeSetEvent;
+use Cake\Cache\Event\CacheClearedEvent;
+use Cake\Cache\Event\CacheGroupClearEvent;
+use DateInterval;
+use LogicException;
+use SplFileInfo;
+use Throwable;
+
+/**
+ * PHP Cache Engine
+ *
+ * Stores cache data as executable PHP files using brick/varexporter.
+ * This enables OPcache acceleration for fast reads on mostly static caches.
+ *
+ * @extends \Cake\Cache\CacheEngine<\Shim\Cache\Engine\PhpEngine>
+ */
+class PhpEngine extends CacheEngine {
+
+	/**
+	 * The default config used unless overridden by runtime configuration
+	 *
+	 * - `duration` Specify how long items in this cache configuration last.
+	 *    0 means indefinite.
+	 * - `groups` List of groups or 'tags' associated to every key stored in this config.
+	 * - `mask` The mask used for created files
+	 * - `dirMask` The mask used for created folders
+	 * - `path` Path to where cache files should be saved. Defaults to system's temp dir.
+	 * - `prefix` Prepended to all entries.
+	 *
+	 * @var array<string, mixed>
+	 */
+	protected array $_defaultConfig = [
+		'duration' => 0,
+		'groups' => [],
+		'mask' => 0664,
+		'dirMask' => 0777,
+		'path' => null,
+		'prefix' => 'cake_',
+	];
+
+	/**
+	 * True unless init/active fails.
+	 *
+	 * @var bool
+	 */
+	protected bool $_init = true;
+
+	/**
+	 * @param array<string, mixed> $config Config array.
+	 * @return bool
+	 */
+	public function init(array $config = []): bool {
+		parent::init($config);
+
+		$this->_config['path'] ??= sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cake_php_cache' . DIRECTORY_SEPARATOR;
+		if (substr($this->_config['path'], -1) !== DIRECTORY_SEPARATOR) {
+			$this->_config['path'] .= DIRECTORY_SEPARATOR;
+		}
+
+		if ($this->_groupPrefix) {
+			$this->_groupPrefix = str_replace('_', DIRECTORY_SEPARATOR, $this->_groupPrefix);
+		}
+
+		if (!class_exists(VarExporter::class)) {
+			$this->_init = false;
+			$this->warning(
+				'PhpEngine requires `brick/varexporter`. Add it to your application dependencies to use this cache engine.',
+			);
+
+			return false;
+		}
+
+		return $this->_active();
+	}
+
+	/**
+	 * @param string $key Identifier for the data
+	 * @param mixed $value Data to be cached
+	 * @param \DateInterval|int|null $ttl Optional TTL value.
+	 * @return bool
+	 */
+	public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool {
+		if (!$this->_init) {
+			return false;
+		}
+
+		$duration = $this->duration($ttl);
+		$key = $this->_key($key);
+
+		$this->_eventClass = CacheBeforeSetEvent::class;
+		$this->dispatchEvent(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $duration]);
+
+		$this->_eventClass = CacheAfterSetEvent::class;
+		$path = $this->_path($key);
+
+		try {
+			$exported = VarExporter::export($value);
+		} catch (Throwable $e) {
+			$this->warning(sprintf(
+				'PhpEngine failed to export value for key `%s`: %s',
+				$key,
+				$e->getMessage(),
+			));
+
+			$this->dispatchEvent(CacheAfterSetEvent::NAME, [
+				'key' => $key, 'value' => $value, 'success' => false, 'ttl' => $duration,
+			]);
+
+			return false;
+		}
+
+		if ($duration > 0) {
+			$expires = time() + $duration;
+			$contents = "<?php\n// Expires: {$expires}\nreturn time() > {$expires} ? null : {$exported};\n";
+		} else {
+			$contents = "<?php\nreturn {$exported};\n";
+		}
+
+		$success = $this->_writeFile($path, $contents);
+
+		$this->dispatchEvent(CacheAfterSetEvent::NAME, [
+			'key' => $key, 'value' => $value, 'success' => $success, 'ttl' => $duration,
+		]);
+
+		return $success;
+	}
+
+	/**
+	 * @param string $key Identifier for the data
+	 * @param mixed $default Default value to return if the key does not exist.
+	 * @return mixed
+	 */
+	public function get(string $key, mixed $default = null): mixed {
+		$key = $this->_key($key);
+
+		$this->_eventClass = CacheBeforeGetEvent::class;
+		$this->dispatchEvent(CacheBeforeGetEvent::NAME, ['key' => $key, 'default' => $default]);
+
+		$this->_eventClass = CacheAfterGetEvent::class;
+		if (!$this->_init) {
+			$this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+
+			return $default;
+		}
+
+		$path = $this->_path($key);
+		if (!is_file($path)) {
+			$this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+
+			return $default;
+		}
+
+		try {
+			$value = require $path;
+		} catch (Throwable $e) {
+			$this->warning(sprintf(
+				'PhpEngine failed to read cache file `%s`: %s',
+				$path,
+				$e->getMessage(),
+			));
+			$this->_deleteFile($path);
+
+			$this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+
+			return $default;
+		}
+
+		if ($value === null) {
+			$this->_deleteFile($path);
+
+			$this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
+
+			return $default;
+		}
+
+		$this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => $value, 'success' => true]);
+
+		return $value;
+	}
+
+	/**
+	 * @param string $key Identifier for the data
+	 * @return bool
+	 */
+	public function delete(string $key): bool {
+		$key = $this->_key($key);
+
+		$this->_eventClass = CacheBeforeDeleteEvent::class;
+		$this->dispatchEvent(CacheBeforeDeleteEvent::NAME, ['key' => $key]);
+
+		$this->_eventClass = CacheAfterDeleteEvent::class;
+		if (!$this->_init) {
+			$this->dispatchEvent(CacheAfterDeleteEvent::NAME, ['key' => $key, 'success' => false]);
+
+			return false;
+		}
+
+		$success = $this->_deleteFile($this->_path($key));
+
+		$this->dispatchEvent(CacheAfterDeleteEvent::NAME, ['key' => $key, 'success' => $success]);
+
+		return $success;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function clear(): bool {
+		if (!$this->_init) {
+			return false;
+		}
+
+		$this->_clearDirectory($this->_config['path']);
+
+		$this->_eventClass = CacheClearedEvent::class;
+		$this->dispatchEvent(CacheClearedEvent::NAME);
+
+		return true;
+	}
+
+	/**
+	 * @param string $key The key to increment
+	 * @param int $offset The number to offset
+	 * @return int|false
+	 */
+	public function increment(string $key, int $offset = 1): int|false {
+		throw new LogicException('PhpEngine does not support atomic increment.');
+	}
+
+	/**
+	 * @param string $key The key to decrement
+	 * @param int $offset The number to offset
+	 * @return int|false
+	 */
+	public function decrement(string $key, int $offset = 1): int|false {
+		throw new LogicException('PhpEngine does not support atomic decrement.');
+	}
+
+	/**
+	 * @param string $group The group to clear.
+	 * @return bool
+	 */
+	public function clearGroup(string $group): bool {
+		$path = $this->_config['path'] . $group . DIRECTORY_SEPARATOR;
+		if (is_dir($path)) {
+			$this->_clearDirectory($path);
+		}
+
+		$this->_eventClass = CacheGroupClearEvent::class;
+		$this->dispatchEvent(CacheGroupClearEvent::NAME, ['group' => $group]);
+
+		return true;
+	}
+
+	/**
+	 * @param string $key The cache key
+	 * @return string
+	 */
+	protected function _path(string $key): string {
+		$groups = null;
+		if ($this->_groupPrefix) {
+			$groups = vsprintf($this->_groupPrefix, $this->groups());
+		}
+
+		$dir = $this->_config['path'] . $groups;
+		if (!is_dir($dir)) {
+			mkdir($dir, $this->_config['dirMask'] ^ umask(), true);
+		}
+
+		return $dir . $key . '.php';
+	}
+
+	/**
+	 * @param string $path File path
+	 * @param string $content File content
+	 * @return bool
+	 */
+	protected function _writeFile(string $path, string $content): bool {
+		$dir = dirname($path);
+		if (!is_dir($dir)) {
+			mkdir($dir, $this->_config['dirMask'] ^ umask(), true);
+		}
+
+		$tmpFile = $path . '.tmp.' . uniqid('', true);
+		if (file_put_contents($tmpFile, $content, LOCK_EX) === false) {
+			return false;
+		}
+
+		chmod($tmpFile, $this->_config['mask']);
+
+		if (!rename($tmpFile, $path)) {
+			// phpcs:disable
+			@unlink($tmpFile);
+			// phpcs:enable
+
+			return false;
+		}
+
+		if (function_exists('opcache_invalidate')) {
+			opcache_invalidate($path, true);
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param string $path File path
+	 * @return bool
+	 */
+	protected function _deleteFile(string $path): bool {
+		if (!is_file($path)) {
+			return false;
+		}
+
+		if (function_exists('opcache_invalidate')) {
+			opcache_invalidate($path, true);
+		}
+
+		// phpcs:disable
+		return @unlink($path);
+		// phpcs:enable
+	}
+
+	/**
+	 * @param string $path Directory path
+	 * @return void
+	 */
+	protected function _clearDirectory(string $path): void {
+		if (!is_dir($path)) {
+			return;
+		}
+
+		$prefix = $this->_config['prefix'];
+		$prefixLength = strlen($prefix);
+
+		$dir = dir($path);
+		if (!$dir) {
+			return;
+		}
+
+		while (($entry = $dir->read()) !== false) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+
+			$fullPath = $path . $entry;
+			if (is_dir($fullPath)) {
+				$this->_clearDirectory($fullPath . DIRECTORY_SEPARATOR);
+				// phpcs:disable
+				@rmdir($fullPath);
+				// phpcs:enable
+				continue;
+			}
+
+			if (substr($entry, 0, $prefixLength) !== $prefix) {
+				continue;
+			}
+
+			$this->_deleteFile($fullPath);
+		}
+
+		$dir->close();
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function _active(): bool {
+		$dir = new SplFileInfo($this->_config['path']);
+		$path = $dir->getPathname();
+		$success = true;
+
+		if (!is_dir($path)) {
+			// phpcs:disable
+			$success = @mkdir($path, $this->_config['dirMask'] ^ umask(), true);
+			// phpcs:enable
+		}
+
+		$isWritableDir = ($dir->isDir() && $dir->isWritable());
+		if (!$success || ($this->_init && !$isWritableDir)) {
+			$this->_init = false;
+			$this->warning(sprintf(
+				'%s is not writable',
+				$this->_config['path'],
+			));
+		}
+
+		return $success;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function _key(string $key): string {
+		$key = parent::_key($key);
+
+		return rawurlencode($key);
+	}
+
+}

--- a/src/Cache/Engine/PhpEngine.php
+++ b/src/Cache/Engine/PhpEngine.php
@@ -434,11 +434,17 @@ class PhpEngine extends CacheEngine {
 	/**
 	 * Dispatch cache events across CakePHP 5.x minors.
 	 *
+	 * CakePHP 5.1 has no event dispatcher on `CacheEngine`; the trait was added
+	 * in 5.2. On 5.1 we silently skip dispatching to keep this engine usable.
+	 *
 	 * @param string $name Event name.
 	 * @param array<string, mixed> $data Event data.
 	 * @return void
 	 */
 	protected function _dispatchEventCompat(string $name, array $data = []): void {
+		if (!method_exists($this, 'getEventManager')) {
+			return;
+		}
 		$this->getEventManager()->dispatch(new Event($name, $this, $data));
 	}
 

--- a/src/Cache/Engine/PhpEngine.php
+++ b/src/Cache/Engine/PhpEngine.php
@@ -116,7 +116,10 @@ class PhpEngine extends CacheEngine {
 			));
 
 			$this->dispatchEvent(CacheAfterSetEvent::NAME, [
-				'key' => $key, 'value' => $value, 'success' => false, 'ttl' => $duration,
+				'key' => $key,
+				'value' => $value,
+				'success' => false,
+				'ttl' => $duration,
 			]);
 
 			return false;
@@ -132,7 +135,10 @@ class PhpEngine extends CacheEngine {
 		$success = $this->_writeFile($path, $contents);
 
 		$this->dispatchEvent(CacheAfterSetEvent::NAME, [
-			'key' => $key, 'value' => $value, 'success' => $success, 'ttl' => $duration,
+			'key' => $key,
+			'value' => $value,
+			'success' => $success,
+			'ttl' => $duration,
 		]);
 
 		return $success;
@@ -362,6 +368,7 @@ class PhpEngine extends CacheEngine {
 				// phpcs:disable
 				@rmdir($fullPath);
 				// phpcs:enable
+
 				continue;
 			}
 

--- a/tests/TestCase/Cache/Engine/PhpEngineTest.php
+++ b/tests/TestCase/Cache/Engine/PhpEngineTest.php
@@ -51,6 +51,7 @@ class PhpEngineTest extends TestCase {
 		foreach ($files as $file) {
 			if (is_file($file)) {
 				unlink($file);
+
 				continue;
 			}
 
@@ -167,6 +168,7 @@ class PhpEngineTest extends TestCase {
 			foreach ($entries as $entry) {
 				if (is_dir($entry)) {
 					$this->_deleteDir($entry);
+
 					continue;
 				}
 

--- a/tests/TestCase/Cache/Engine/PhpEngineTest.php
+++ b/tests/TestCase/Cache/Engine/PhpEngineTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shim\Test\TestCase\Cache\Engine;
+
+use Cake\Cache\Cache;
+use Cake\TestSuite\TestCase;
+use LogicException;
+use Shim\Cache\Engine\PhpEngine;
+use stdClass;
+
+class PhpEngineTest extends TestCase {
+
+	/**
+	 * @var string
+	 */
+	protected string $cachePath;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->cachePath = TMP . 'tests' . DS . 'php_cache' . DS;
+		if (!is_dir($this->cachePath)) {
+			mkdir($this->cachePath, 0777, true);
+		}
+
+		Cache::setConfig('php_test', [
+			'className' => PhpEngine::class,
+			'path' => $this->cachePath,
+			'prefix' => 'cake_',
+			'duration' => 3600,
+		]);
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		Cache::drop('php_test');
+		Cache::drop('php_test_expiry');
+
+		if (!is_dir($this->cachePath)) {
+			return;
+		}
+
+		$files = glob($this->cachePath . '*');
+		if ($files === false) {
+			return;
+		}
+
+		foreach ($files as $file) {
+			if (is_file($file)) {
+				unlink($file);
+				continue;
+			}
+
+			if (is_dir($file)) {
+				$this->_deleteDir($file);
+			}
+		}
+	}
+
+	public function testSetAndGet(): void {
+		$result = Cache::write('test_key', 'test_value', 'php_test');
+		$this->assertTrue($result);
+
+		$value = Cache::read('test_key', 'php_test');
+		$this->assertSame('test_value', $value);
+	}
+
+	public function testSetAndGetArray(): void {
+		$data = ['foo' => 'bar', 'nested' => ['a' => 1, 'b' => 2]];
+
+		Cache::write('array_key', $data, 'php_test');
+		$result = Cache::read('array_key', 'php_test');
+
+		$this->assertSame($data, $result);
+	}
+
+	public function testSetAndGetObject(): void {
+		$data = new stdClass();
+		$data->name = 'test';
+		$data->value = 42;
+
+		Cache::write('object_key', $data, 'php_test');
+		$result = Cache::read('object_key', 'php_test');
+
+		$this->assertEquals($data, $result);
+	}
+
+	public function testDelete(): void {
+		Cache::write('delete_key', 'value', 'php_test');
+		$this->assertSame('value', Cache::read('delete_key', 'php_test'));
+
+		$result = Cache::delete('delete_key', 'php_test');
+		$this->assertTrue($result);
+		$this->assertNull(Cache::read('delete_key', 'php_test'));
+	}
+
+	public function testClear(): void {
+		Cache::write('key1', 'value1', 'php_test');
+		Cache::write('key2', 'value2', 'php_test');
+
+		$result = Cache::clear('php_test');
+		$this->assertTrue($result);
+		$this->assertNull(Cache::read('key1', 'php_test'));
+		$this->assertNull(Cache::read('key2', 'php_test'));
+	}
+
+	public function testCacheFileIsValidPhp(): void {
+		Cache::write('php_key', ['test' => 'data'], 'php_test');
+
+		$files = glob($this->cachePath . 'cake_*');
+		$this->assertIsArray($files);
+		$this->assertNotEmpty($files);
+
+		$value = require $files[0];
+		$this->assertSame(['test' => 'data'], $value);
+	}
+
+	public function testExpiration(): void {
+		Cache::setConfig('php_test_expiry', [
+			'className' => PhpEngine::class,
+			'path' => $this->cachePath,
+			'prefix' => 'cake_expiry_',
+			'duration' => 1,
+		]);
+
+		Cache::write('expiring_key', 'value', 'php_test_expiry');
+		$this->assertSame('value', Cache::read('expiring_key', 'php_test_expiry'));
+
+		sleep(2);
+
+		$this->assertNull(Cache::read('expiring_key', 'php_test_expiry'));
+	}
+
+	public function testSpecialCharactersInKey(): void {
+		Cache::write('key/with:special.chars', 'value', 'php_test');
+		$this->assertSame('value', Cache::read('key/with:special.chars', 'php_test'));
+	}
+
+	public function testIncrementThrowsException(): void {
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('PhpEngine does not support atomic increment');
+
+		$engine = new PhpEngine();
+		$engine->init(['path' => $this->cachePath]);
+		$engine->increment('key');
+	}
+
+	public function testDecrementThrowsException(): void {
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('PhpEngine does not support atomic decrement');
+
+		$engine = new PhpEngine();
+		$engine->init(['path' => $this->cachePath]);
+		$engine->decrement('key');
+	}
+
+	/**
+	 * @param string $path
+	 * @return void
+	 */
+	protected function _deleteDir(string $path): void {
+		$entries = glob($path . DS . '*');
+		if ($entries !== false) {
+			foreach ($entries as $entry) {
+				if (is_dir($entry)) {
+					$this->_deleteDir($entry);
+					continue;
+				}
+
+				unlink($entry);
+			}
+		}
+
+		rmdir($path);
+	}
+
+}

--- a/tests/benchmark/cache_engine_benchmark.php
+++ b/tests/benchmark/cache_engine_benchmark.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+use Cake\Cache\Cache;
+use Shim\Cache\Engine\PhpEngine;
+
+require dirname(__DIR__) . '/bootstrap.php';
+
+if (!class_exists(\Brick\VarExporter\VarExporter::class)) {
+	fwrite(STDERR, "Missing dependency: brick/varexporter\n");
+	fwrite(STDERR, "Install it with: composer require brick/varexporter\n");
+	exit(1);
+}
+
+$options = getopt('', ['writes::', 'reads::']);
+$writes = max(1, (int)($options['writes'] ?? 100));
+$reads = max(1, (int)($options['reads'] ?? 500));
+
+$benchmarkRoot = TMP . 'benchmarks' . DS . 'cache_engines' . DS;
+ensureDir($benchmarkRoot);
+
+$engines = [
+	'File' => [
+		'className' => 'File',
+		'path' => $benchmarkRoot . 'file' . DS,
+		'prefix' => 'bench_',
+		'duration' => 0,
+		'serialize' => true,
+	],
+	'PhpEngine' => [
+		'className' => PhpEngine::class,
+		'path' => $benchmarkRoot . 'php' . DS,
+		'prefix' => 'bench_',
+		'duration' => 0,
+	],
+];
+
+$payloads = [
+	'translations' => buildTranslationsPayload(),
+	'model_cache' => buildModelCachePayload(),
+	'nested_config' => buildNestedConfigPayload(),
+	'record_list' => buildRecordListPayload(),
+];
+
+foreach ($engines as $name => $config) {
+	Cache::drop($name);
+	cleanDir($config['path']);
+	Cache::setConfig($name, $config);
+}
+
+$results = [];
+foreach ($payloads as $payloadName => $payload) {
+	foreach (array_keys($engines) as $engineName) {
+		Cache::clear($engineName);
+		$results[] = runBenchmark($engineName, $payloadName, $payload, $writes, $reads);
+	}
+}
+
+printHeader($writes, $reads);
+printResults($results);
+
+foreach (array_keys($engines) as $engineName) {
+	Cache::drop($engineName);
+}
+
+/**
+ * @param string $engineName
+ * @param string $payloadName
+ * @param mixed $payload
+ * @param int $writes
+ * @param int $reads
+ * @return array<string, mixed>
+ */
+function runBenchmark(string $engineName, string $payloadName, mixed $payload, int $writes, int $reads): array {
+	$writeStart = hrtime(true);
+	for ($i = 0; $i < $writes; $i++) {
+		Cache::write($payloadName . '_' . $i, $payload, $engineName);
+	}
+	$writeNs = hrtime(true) - $writeStart;
+
+	$readStart = hrtime(true);
+	for ($i = 0; $i < $reads; $i++) {
+		$key = $payloadName . '_' . ($i % $writes);
+		Cache::read($key, $engineName);
+	}
+	$readNs = hrtime(true) - $readStart;
+
+	$payloadBytes = strlen(serialize($payload));
+
+	return [
+		'engine' => $engineName,
+		'payload' => $payloadName,
+		'size_kb' => round($payloadBytes / 1024, 2),
+		'write_ms' => nsToMs($writeNs),
+		'read_ms' => nsToMs($readNs),
+		'write_us_per_op' => round(($writeNs / 1000) / $writes, 2),
+		'read_us_per_op' => round(($readNs / 1000) / $reads, 2),
+	];
+}
+
+/**
+ * @return array<string, array<string, string>>
+ */
+function buildTranslationsPayload(): array {
+	$payload = [];
+	for ($domain = 1; $domain <= 12; $domain++) {
+		$domainName = 'domain_' . $domain;
+		for ($message = 1; $message <= 150; $message++) {
+			$key = 'message_' . $message;
+			$payload[$domainName][$key] = sprintf(
+				'Translated text %d for %s with placeholder {name} and count {count}.',
+				$message,
+				$domainName,
+			);
+		}
+	}
+
+	return $payload;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function buildModelCachePayload(): array {
+	$columns = [];
+	for ($i = 1; $i <= 45; $i++) {
+		$name = 'field_' . $i;
+		$columns[$name] = [
+			'type' => match ($i % 5) {
+				0 => 'integer',
+				1 => 'string',
+				2 => 'datetime',
+				3 => 'boolean',
+				default => 'decimal',
+			},
+			'length' => $i % 5 === 1 ? 255 : null,
+			'null' => $i % 7 !== 0,
+			'default' => $i % 3 === 0 ? null : 'value_' . $i,
+			'comment' => 'Column comment ' . $i,
+			'precision' => $i % 5 === 4 ? 10 : null,
+			'scale' => $i % 5 === 4 ? 2 : null,
+		];
+	}
+
+	return [
+		'table' => 'articles',
+		'primaryKey' => ['id'],
+		'displayField' => 'title',
+		'schema' => $columns,
+		'indexes' => [
+			'PRIMARY' => ['type' => 'primary', 'columns' => ['id']],
+			'published' => ['type' => 'index', 'columns' => ['is_published', 'published']],
+			'slug' => ['type' => 'unique', 'columns' => ['slug']],
+		],
+		'associations' => [
+			'Authors' => ['type' => 'belongsTo', 'foreignKey' => 'author_id'],
+			'Comments' => ['type' => 'hasMany', 'foreignKey' => 'article_id'],
+			'Tags' => ['type' => 'belongsToMany', 'foreignKey' => 'article_id', 'targetForeignKey' => 'tag_id'],
+		],
+		'behaviors' => [
+			'Timestamp' => ['events' => ['Model.beforeSave' => ['created', 'modified']]],
+			'CounterCache' => ['Comments' => ['comment_count']],
+		],
+	];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function buildNestedConfigPayload(): array {
+	return [
+		'app' => [
+			'name' => 'ShimBenchmark',
+			'debug' => false,
+			'fullBaseUrl' => 'https://example.com',
+			'paths' => [
+				'plugins' => ['plugins/', 'vendor/plugins/'],
+				'templates' => ['templates/', 'plugins/*/templates/'],
+				'locales' => ['resources/locales/'],
+			],
+		],
+		'routes' => array_map(
+			static fn (int $i): array => [
+				'template' => '/articles/' . $i . '/:slug',
+				'defaults' => ['controller' => 'Articles', 'action' => 'view', 'id' => $i],
+				'options' => ['_method' => ['GET'], '_ext' => ['json', 'xml']],
+			],
+			range(1, 250),
+		),
+		'featureFlags' => array_combine(
+			array_map(static fn (int $i): string => 'feature_' . $i, range(1, 120)),
+			array_map(static fn (int $i): bool => $i % 2 === 0, range(1, 120)),
+		),
+	];
+}
+
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function buildRecordListPayload(): array {
+	$records = [];
+	for ($i = 1; $i <= 350; $i++) {
+		$records[] = [
+			'id' => $i,
+			'title' => 'Article ' . $i,
+			'slug' => 'article-' . $i,
+			'body' => str_repeat('Lorem ipsum dolor sit amet. ', 6),
+			'is_published' => $i % 3 !== 0,
+			'author' => [
+				'id' => ($i % 20) + 1,
+				'name' => 'Author ' . (($i % 20) + 1),
+			],
+			'tags' => ['cakephp', 'cache', 'benchmark', 'payload-' . ($i % 10)],
+			'created' => '2026-05-05 10:00:00',
+		];
+	}
+
+	return $records;
+}
+
+/**
+ * @param array<int, array<string, mixed>> $results
+ * @return void
+ */
+function printResults(array $results): void {
+	printf(
+		"%-14s %-14s %10s %12s %12s %14s %14s\n",
+		'Engine',
+		'Payload',
+		'Size KB',
+		'Write ms',
+		'Read ms',
+		'Write us/op',
+		'Read us/op',
+	);
+	echo str_repeat('-', 96) . PHP_EOL;
+
+	foreach ($results as $row) {
+		printf(
+			"%-14s %-14s %10.2f %12.2f %12.2f %14.2f %14.2f\n",
+			$row['engine'],
+			$row['payload'],
+			$row['size_kb'],
+			$row['write_ms'],
+			$row['read_ms'],
+			$row['write_us_per_op'],
+			$row['read_us_per_op'],
+		);
+	}
+}
+
+/**
+ * @param int $writes
+ * @param int $reads
+ * @return void
+ */
+function printHeader(int $writes, int $reads): void {
+	echo 'Cache engine benchmark' . PHP_EOL;
+	echo 'Writes per payload: ' . $writes . PHP_EOL;
+	echo 'Reads per payload: ' . $reads . PHP_EOL;
+	if (!filter_var(ini_get('opcache.enable_cli'), FILTER_VALIDATE_BOOL)) {
+		echo 'Note: opcache.enable_cli=0, so PhpEngine read timings here do not reflect OPcache-assisted reads.' . PHP_EOL;
+		echo 'Run with `php -d opcache.enable_cli=1 tests/benchmark/cache_engine_benchmark.php` for a fairer CLI comparison.' . PHP_EOL;
+	}
+	echo PHP_EOL;
+}
+
+/**
+ * @param int $ns
+ * @return float
+ */
+function nsToMs(int $ns): float {
+	return round($ns / 1000000, 2);
+}
+
+/**
+ * @param string $path
+ * @return void
+ */
+function ensureDir(string $path): void {
+	if (!is_dir($path)) {
+		mkdir($path, 0777, true);
+	}
+}
+
+/**
+ * @param string $path
+ * @return void
+ */
+function cleanDir(string $path): void {
+	if (!is_dir($path)) {
+		mkdir($path, 0777, true);
+		return;
+	}
+
+	$items = glob($path . '*');
+	if ($items === false) {
+		return;
+	}
+
+	foreach ($items as $item) {
+		if (is_dir($item)) {
+			cleanDir($item . DS);
+			rmdir($item);
+			continue;
+		}
+
+		unlink($item);
+	}
+}

--- a/tests/benchmark/cache_engine_benchmark.php
+++ b/tests/benchmark/cache_engine_benchmark.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
+use Brick\VarExporter\VarExporter;
 use Cake\Cache\Cache;
 use Shim\Cache\Engine\PhpEngine;
 
 require dirname(__DIR__) . '/bootstrap.php';
 
-if (!class_exists(\Brick\VarExporter\VarExporter::class)) {
+if (!class_exists(VarExporter::class)) {
 	fwrite(STDERR, "Missing dependency: brick/varexporter\n");
 	fwrite(STDERR, "Install it with: composer require brick/varexporter\n");
 	exit(1);
@@ -291,6 +292,7 @@ function ensureDir(string $path): void {
 function cleanDir(string $path): void {
 	if (!is_dir($path)) {
 		mkdir($path, 0777, true);
+
 		return;
 	}
 
@@ -303,6 +305,7 @@ function cleanDir(string $path): void {
 		if (is_dir($item)) {
 			cleanDir($item . DS);
 			rmdir($item);
+
 			continue;
 		}
 


### PR DESCRIPTION
## Summary

This backports CakePHP 6.x's cache PhpEngine into the shim plugin for CakePHP 5.

It adds:
- `Shim\Cache\Engine\PhpEngine`
- focused test coverage
- docs for installing `brick/varexporter`
- a local benchmark script for comparing `File` vs `PhpEngine`

## Notes

`brick/varexporter` remains an app-installed dependency for consumers using this engine.

## Verification

- `vendor/bin/phpunit tests/TestCase/Cache/Engine/PhpEngineTest.php`
- `php tests/benchmark/cache_engine_benchmark.php --writes=5 --reads=10`
- `php -d opcache.enable_cli=1 tests/benchmark/cache_engine_benchmark.php --writes=10 --reads=25`
