### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Annotator/ClassAnnotatorTask/LegacyModelAwareClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/LegacyModelAwareClassAnnotatorTask.php
@@ -34,7 +34,7 @@ class LegacyModelAwareClassAnnotatorTask extends ModelAwareClassAnnotatorTask {
 
 		try {
 			return (new ReflectionClass($className))->hasMethod('loadModel');
-		} catch (Throwable $exception) {
+		} catch (Throwable) {
 			return false;
 		}
 	}

--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -38,10 +38,10 @@ class EntityAnnotator extends IdeHelperEntityAnnotator {
 		foreach ($methodTypes as $methodType) {
 			foreach ($propertyHintMap as $field => $type) {
 				if ($methodType === 'set') {
-					if (str_contains((string) $type, '|null')) {
+					if (str_contains((string)$type, '|null')) {
 						$type = str_replace('|null', '', $type);
 					}
-					if (preg_match('/^(\w+)[<\[]/', (string) $type, $matches)) {
+					if (preg_match('/^(\w+)[<\[]/', (string)$type, $matches)) {
 						$type = $matches[1];
 					}
 
@@ -49,7 +49,7 @@ class EntityAnnotator extends IdeHelperEntityAnnotator {
 					$type = '$this';
 				} else {
 					$method = $methodType . Inflector::camelize($field) . 'OrFail()';
-					if (str_contains((string) $type, '|null')) {
+					if (str_contains((string)$type, '|null')) {
 						$type = str_replace('|null', '', $type);
 					}
 				}

--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -38,10 +38,10 @@ class EntityAnnotator extends IdeHelperEntityAnnotator {
 		foreach ($methodTypes as $methodType) {
 			foreach ($propertyHintMap as $field => $type) {
 				if ($methodType === 'set') {
-					if (strpos($type, '|null') !== false) {
+					if (str_contains((string) $type, '|null')) {
 						$type = str_replace('|null', '', $type);
 					}
-					if (preg_match('/^(\w+)[<\[]/', $type, $matches)) {
+					if (preg_match('/^(\w+)[<\[]/', (string) $type, $matches)) {
 						$type = $matches[1];
 					}
 
@@ -49,7 +49,7 @@ class EntityAnnotator extends IdeHelperEntityAnnotator {
 					$type = '$this';
 				} else {
 					$method = $methodType . Inflector::camelize($field) . 'OrFail()';
-					if (strpos($type, '|null') !== false) {
+					if (str_contains((string) $type, '|null')) {
 						$type = str_replace('|null', '', $type);
 					}
 				}

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -378,11 +378,7 @@ class RequestHandlerComponent extends Component {
 		$options += $defaults;
 
 		$builder = $controller->viewBuilder();
-		if (array_key_exists($type, $viewClassMap)) {
-			$view = $viewClassMap[$type];
-		} else {
-			$view = Inflector::classify($type);
-		}
+		$view = array_key_exists($type, $viewClassMap) ? $viewClassMap[$type] : Inflector::classify($type);
 
 		$viewClass = null;
 		if ($builder->getClassName() === null) {
@@ -393,7 +389,7 @@ class RequestHandlerComponent extends Component {
 			$builder->setClassName($viewClass);
 		} else {
 			if (!$this->_renderType) {
-				$builder->setTemplatePath((string)$builder->getTemplatePath() . DIRECTORY_SEPARATOR . $type);
+				$builder->setTemplatePath($builder->getTemplatePath() . DIRECTORY_SEPARATOR . $type);
 			} else {
 				$builder->setTemplatePath(preg_replace(
 					"/([\/\\\\]{$this->_renderType})$/",
@@ -431,7 +427,7 @@ class RequestHandlerComponent extends Component {
 		$controller = $this->getController();
 		$response = $controller->getResponse();
 
-		if (strpos($type, '/') === false) {
+		if (!str_contains($type, '/')) {
 			$cType = $response->getMimeType($type);
 		}
 		if (is_array($cType)) {
@@ -469,7 +465,7 @@ class RequestHandlerComponent extends Component {
 	 */
 	public function mapAlias($alias) {
 		if (is_array($alias)) {
-			return array_map([$this, 'mapAlias'], $alias);
+			return array_map($this->mapAlias(...), $alias);
 		}
 
 		$type = $this->getController()->getResponse()->getMimeType($alias);

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -70,12 +70,12 @@ class Controller extends CoreController {
 	 */
 	public function afterFilter(EventInterface $event): void {
 		if (Configure::read('Shim.monitorHeaders') && $this->name !== 'Error' && PHP_SAPI !== 'cli' && headers_sent($filename, $lineNumber)) {
-            $message = sprintf('Headers already sent in %s on line %s', $filename, $lineNumber);
-            if (Configure::read('debug')) {
+			$message = sprintf('Headers already sent in %s on line %s', $filename, $lineNumber);
+			if (Configure::read('debug')) {
 					throw new Exception($message);
-				}
-            trigger_error($message);
-        }
+			}
+			trigger_error($message);
+		}
 	}
 
 	/**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -69,15 +69,13 @@ class Controller extends CoreController {
 	 * @return void
 	 */
 	public function afterFilter(EventInterface $event): void {
-		if (Configure::read('Shim.monitorHeaders') && $this->name !== 'Error' && PHP_SAPI !== 'cli') {
-			if (headers_sent($filename, $lineNumber)) {
-				$message = sprintf('Headers already sent in %s on line %s', $filename, $lineNumber);
-				if (Configure::read('debug')) {
+		if (Configure::read('Shim.monitorHeaders') && $this->name !== 'Error' && PHP_SAPI !== 'cli' && headers_sent($filename, $lineNumber)) {
+            $message = sprintf('Headers already sent in %s on line %s', $filename, $lineNumber);
+            if (Configure::read('debug')) {
 					throw new Exception($message);
 				}
-				trigger_error($message);
-			}
-		}
+            trigger_error($message);
+        }
 	}
 
 	/**

--- a/src/Database/Type/TimeStringType.php
+++ b/src/Database/Type/TimeStringType.php
@@ -35,9 +35,6 @@ class TimeStringType extends BaseType {
 		if ($value !== null) {
 			$value = $this->normalize($value);
 		}
-		if ($value === null) {
-			return null;
-		}
 
 		return $value;
 	}
@@ -50,10 +47,6 @@ class TimeStringType extends BaseType {
 	 * @return string|null
 	 */
 	public function toPHP(mixed $value, Driver $driver): mixed {
-		if ($value === null) {
-			return null;
-		}
-
 		return $value;
 	}
 
@@ -67,9 +60,6 @@ class TimeStringType extends BaseType {
 		}
 		if ($value !== null) {
 			$value = $this->normalize($value);
-		}
-		if ($value === null) {
-			return null;
 		}
 
 		return $value;
@@ -104,7 +94,7 @@ class TimeStringType extends BaseType {
 	 * @return string|null
 	 */
 	protected function normalize(string $value): ?string {
-		if (!preg_match('#^(([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|24:00:00)$#', $value)) {
+		if (!preg_match('#^(([0-1]\d|2[0-3]):[0-5]\d:[0-5]\d|24:00:00)$#', $value)) {
 			return null;
 		}
 		if (static::$normalizeUpperBoundary && $value === '24:00:00') {

--- a/src/Datasource/LegacyModelAwareTrait.php
+++ b/src/Datasource/LegacyModelAwareTrait.php
@@ -55,7 +55,7 @@ trait LegacyModelAwareTrait {
 		$modelType ??= $this->getModelType();
 
 		$options = [];
-		if (strpos($modelClass, '\\') === false) {
+		if (!str_contains($modelClass, '\\')) {
 			[, $alias] = pluginSplit($modelClass, true);
 		} else {
 			$options['className'] = $modelClass;
@@ -63,7 +63,7 @@ trait LegacyModelAwareTrait {
 			$alias = substr(
 				$modelClass,
 				strrpos($modelClass, '\\') + 1,
-				-strlen($modelType),
+				-strlen((string) $modelType),
 			);
 			$modelClass = $alias;
 		}

--- a/src/Datasource/LegacyModelAwareTrait.php
+++ b/src/Datasource/LegacyModelAwareTrait.php
@@ -63,7 +63,7 @@ trait LegacyModelAwareTrait {
 			$alias = substr(
 				$modelClass,
 				strrpos($modelClass, '\\') + 1,
-				-strlen((string) $modelType),
+				-strlen((string)$modelType),
 			);
 			$modelClass = $alias;
 		}

--- a/src/Deprecations.php
+++ b/src/Deprecations.php
@@ -31,9 +31,7 @@ class Deprecations {
 			return $specificOn;
 		}
 
-		$globalOn = Configure::read('Shim.deprecations') === true;
-
-		return $globalOn;
+		return Configure::read('Shim.deprecations') === true;
 	}
 
 	/**

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -92,7 +92,9 @@ class File {
 			$this->name = ltrim($splInfo->getFilename(), '/\\');
 		}
 		$this->pwd();
-		$create && !$this->exists() && $this->safe($path) && $this->create();
+		if ($create && !$this->exists() && $this->safe($path)) {
+            $this->create();
+        }
 	}
 
 	/**
@@ -109,12 +111,7 @@ class File {
 	 */
 	public function create(): bool {
 		$dir = $this->Folder->pwd();
-
-		if (is_dir($dir) && is_writable($dir) && !$this->exists() && touch($this->path)) {
-			return true;
-		}
-
-		return false;
+        return is_dir($dir) && is_writable($dir) && !$this->exists() && touch($this->path);
 	}
 
 	/**
@@ -195,7 +192,7 @@ class File {
 			if (is_resource($this->handle)) {
 				return ftell($this->handle);
 			}
-		} elseif ($this->open() === true) {
+		} elseif ($this->open()) {
 			return fseek($this->handle, $offset, $seek) === 0;
 		}
 
@@ -213,7 +210,7 @@ class File {
 	 */
 	public static function prepare(string $data, bool $forceWindows = false): string {
 		$lineBreak = "\n";
-		if (DIRECTORY_SEPARATOR === '\\' || $forceWindows === true) {
+		if (DIRECTORY_SEPARATOR === '\\' || $forceWindows) {
 			$lineBreak = "\r\n";
 		}
 
@@ -230,7 +227,7 @@ class File {
 	 */
 	public function write(string $data, string $mode = 'w', bool $force = false): bool {
 		$success = false;
-		if ($this->open($mode, $force) === true) {
+		if ($this->open($mode, $force)) {
 			if ($this->lock !== null && flock($this->handle, LOCK_EX) === false) {
 				return false;
 			}
@@ -299,12 +296,12 @@ class File {
 	 */
 	public function info(): array {
 		if (!$this->info) {
-			$this->info = pathinfo($this->path);
+			$this->info = pathinfo((string) $this->path);
 		}
 
-		$this->info['filename'] = $this->info['filename'] ?? $this->name();
-		$this->info['filesize'] = $this->info['filesize'] ?? $this->size();
-		$this->info['mime'] = $this->info['mime'] ?? $this->mime();
+		$this->info['filename'] ??= $this->name();
+		$this->info['filesize'] ??= $this->size();
+		$this->info['mime'] ??= $this->mime();
 
 		return $this->info;
 	}

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -93,8 +93,8 @@ class File {
 		}
 		$this->pwd();
 		if ($create && !$this->exists() && $this->safe($path)) {
-            $this->create();
-        }
+			$this->create();
+		}
 	}
 
 	/**
@@ -111,7 +111,8 @@ class File {
 	 */
 	public function create(): bool {
 		$dir = $this->Folder->pwd();
-        return is_dir($dir) && is_writable($dir) && !$this->exists() && touch($this->path);
+
+		return is_dir($dir) && is_writable($dir) && !$this->exists() && touch($this->path);
 	}
 
 	/**
@@ -296,7 +297,7 @@ class File {
 	 */
 	public function info(): array {
 		if (!$this->info) {
-			$this->info = pathinfo((string) $this->path);
+			$this->info = pathinfo((string)$this->path);
 		}
 
 		$this->info['filename'] ??= $this->name();

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -122,7 +122,7 @@ class Folder {
 			$this->mode = $mode;
 		}
 
-		if (!file_exists($path) && $create === true) {
+		if (!file_exists($path) && $create) {
 			$this->create($path, $this->mode);
 		}
 		if (!static::isAbsolute($path)) {
@@ -180,7 +180,7 @@ class Folder {
 
 		try {
 			$iterator = new DirectoryIterator((string)$this->path);
-		} catch (Exception $e) {
+		} catch (Exception) {
 			return [$dirs, $files];
 		}
 
@@ -429,7 +429,7 @@ class Folder {
 
 			foreach ($paths as $type) {
 				foreach ($type as $fullpath) {
-					$check = explode(DIRECTORY_SEPARATOR, $fullpath);
+					$check = explode(DIRECTORY_SEPARATOR, (string) $fullpath);
 					$count = count($check);
 
 					if (in_array($check[$count - 1], $exceptions, true)) {
@@ -469,7 +469,7 @@ class Folder {
 
 		try {
 			$iterator = new DirectoryIterator($path);
-		} catch (Exception $e) {
+		} catch (Exception) {
 			return [];
 		}
 
@@ -515,10 +515,10 @@ class Folder {
 		try {
 			$directory = new RecursiveDirectoryIterator(
 				$path,
-				RecursiveDirectoryIterator::KEY_AS_PATHNAME | RecursiveDirectoryIterator::CURRENT_AS_SELF,
+				RecursiveDirectoryIterator::KEY_AS_PATHNAME | RecursiveDirectoryIterator::CURRENT_AS_SELF | \FilesystemIterator::SKIP_DOTS,
 			);
 			$iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::SELF_FIRST);
-		} catch (Exception $e) {
+		} catch (Exception) {
 			unset($directory, $iterator);
 
 			if ($type === null) {
@@ -535,7 +535,7 @@ class Folder {
 		foreach ($iterator as $itemPath => $fsIterator) {
 			if ($skipHidden) {
 				$subPathName = $fsIterator->getSubPathname();
-				if ($subPathName[0] === '.' || strpos($subPathName, DIRECTORY_SEPARATOR . '.') !== false) {
+				if ($subPathName[0] === '.' || str_contains($subPathName, DIRECTORY_SEPARATOR . '.')) {
 					unset($fsIterator);
 
 					continue;
@@ -605,21 +605,18 @@ class Folder {
 		$pathname = rtrim($pathname, DIRECTORY_SEPARATOR);
 		$nextPathname = substr($pathname, 0, (int)strrpos($pathname, DIRECTORY_SEPARATOR));
 
-		if ($this->create($nextPathname, $mode)) {
-			if (!file_exists($pathname)) {
-				$old = umask(0);
-				if (mkdir($pathname, $mode, true)) {
+		if ($this->create($nextPathname, $mode) && !file_exists($pathname)) {
+            $old = umask(0);
+            if (mkdir($pathname, $mode, true)) {
 					$this->_messages[] = sprintf('%s created', $pathname);
 					umask($old);
 
 					return true;
 				}
-				$this->_errors[] = sprintf('%s NOT created', $pathname);
-				umask($old);
-
-				return false;
-			}
-		}
+            $this->_errors[] = sprintf('%s NOT created', $pathname);
+            umask($old);
+            return false;
+        }
 
 		return false;
 	}
@@ -677,9 +674,9 @@ class Folder {
 		if (is_dir($path)) {
 			$directory = $iterator = null;
 			try {
-				$directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF);
+				$directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF | \FilesystemIterator::SKIP_DOTS);
 				$iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::CHILD_FIRST);
-			} catch (Exception $e) {
+			} catch (Exception) {
 				unset($directory, $iterator);
 
 				return false;
@@ -894,7 +891,7 @@ class Folder {
 	 * @return string|false The resolved path
 	 */
 	public function realpath(string $path) {
-		if (strpos($path, '..') === false) {
+		if (!str_contains($path, '..')) {
 			if (!static::isAbsolute($path)) {
 				$path = static::addPathElement((string)$this->path, $path);
 			}

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -609,10 +609,10 @@ class Folder {
 		if ($this->create($nextPathname, $mode) && !file_exists($pathname)) {
 			$old = umask(0);
 			if (mkdir($pathname, $mode, true)) {
-					$this->_messages[] = sprintf('%s created', $pathname);
-					umask($old);
+				$this->_messages[] = sprintf('%s created', $pathname);
+				umask($old);
 
-					return true;
+				return true;
 			}
 			$this->_errors[] = sprintf('%s NOT created', $pathname);
 			umask($old);

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -19,6 +19,7 @@ namespace Shim\Filesystem;
 
 use DirectoryIterator;
 use Exception;
+use FilesystemIterator;
 use InvalidArgumentException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -429,7 +430,7 @@ class Folder {
 
 			foreach ($paths as $type) {
 				foreach ($type as $fullpath) {
-					$check = explode(DIRECTORY_SEPARATOR, (string) $fullpath);
+					$check = explode(DIRECTORY_SEPARATOR, (string)$fullpath);
 					$count = count($check);
 
 					if (in_array($check[$count - 1], $exceptions, true)) {
@@ -515,7 +516,7 @@ class Folder {
 		try {
 			$directory = new RecursiveDirectoryIterator(
 				$path,
-				RecursiveDirectoryIterator::KEY_AS_PATHNAME | RecursiveDirectoryIterator::CURRENT_AS_SELF | \FilesystemIterator::SKIP_DOTS,
+				RecursiveDirectoryIterator::KEY_AS_PATHNAME | RecursiveDirectoryIterator::CURRENT_AS_SELF | FilesystemIterator::SKIP_DOTS,
 			);
 			$iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::SELF_FIRST);
 		} catch (Exception) {
@@ -606,17 +607,18 @@ class Folder {
 		$nextPathname = substr($pathname, 0, (int)strrpos($pathname, DIRECTORY_SEPARATOR));
 
 		if ($this->create($nextPathname, $mode) && !file_exists($pathname)) {
-            $old = umask(0);
-            if (mkdir($pathname, $mode, true)) {
+			$old = umask(0);
+			if (mkdir($pathname, $mode, true)) {
 					$this->_messages[] = sprintf('%s created', $pathname);
 					umask($old);
 
 					return true;
-				}
-            $this->_errors[] = sprintf('%s NOT created', $pathname);
-            umask($old);
-            return false;
-        }
+			}
+			$this->_errors[] = sprintf('%s NOT created', $pathname);
+			umask($old);
+
+			return false;
+		}
 
 		return false;
 	}
@@ -674,7 +676,7 @@ class Folder {
 		if (is_dir($path)) {
 			$directory = $iterator = null;
 			try {
-				$directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF | \FilesystemIterator::SKIP_DOTS);
+				$directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF | FilesystemIterator::SKIP_DOTS);
 				$iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::CHILD_FIRST);
 			} catch (Exception) {
 				unset($directory, $iterator);

--- a/src/Model/Entity/ModifiedTrait.php
+++ b/src/Model/Entity/ModifiedTrait.php
@@ -21,17 +21,11 @@ trait ModifiedTrait {
 		}
 
 		$value = $this->get($name);
-		if (
-			!in_array($name, $this->_originalFields, true) ||
+        return !in_array($name, $this->_originalFields, true) ||
 			(
 				array_key_exists($name, $this->_original) &&
 				($nonStrictComparison && $this->_original[$name] != $value || !$nonStrictComparison && $this->_original[$name] !== $value)
-			)
-		) {
-			return true;
-		}
-
-		return false;
+			);
 	}
 
 	/**

--- a/src/Model/Entity/ModifiedTrait.php
+++ b/src/Model/Entity/ModifiedTrait.php
@@ -21,7 +21,8 @@ trait ModifiedTrait {
 		}
 
 		$value = $this->get($name);
-        return !in_array($name, $this->_originalFields, true) ||
+
+		return !in_array($name, $this->_originalFields, true) ||
 			(
 				array_key_exists($name, $this->_original) &&
 				($nonStrictComparison && $this->_original[$name] != $value || !$nonStrictComparison && $this->_original[$name] !== $value)

--- a/src/Model/Entity/ReadTrait.php
+++ b/src/Model/Entity/ReadTrait.php
@@ -2,7 +2,6 @@
 
 namespace Shim\Model\Entity;
 
-use ArrayAccess;
 use Cake\Datasource\EntityInterface;
 
 /**

--- a/src/Model/Entity/ReadTrait.php
+++ b/src/Model/Entity/ReadTrait.php
@@ -26,15 +26,11 @@ trait ReadTrait {
 	 * @return mixed|null The value fetched from the entity, or null.
 	 */
 	public function read($path, mixed $default = null): mixed {
-		if (!is_array($path)) {
-			$parts = explode('.', $path);
-		} else {
-			$parts = $path;
-		}
+		$parts = is_array($path) ? $path : explode('.', $path);
 
 		$data = null;
 		foreach ($parts as $key) {
-			if ($data === null && !isset($this->$key)) {
+			if (!isset($this->$key)) {
 				return $default;
 			}
 			if ($data === null) {
@@ -47,7 +43,7 @@ trait ReadTrait {
 				$data = $data->toArray();
 			}
 
-			if ((is_array($data) || $data instanceof ArrayAccess) && isset($data[$key])) {
+			if (isset($data[$key])) {
 				$data = $data[$key];
 			} else {
 				return $default;

--- a/src/Model/Entity/ReadTrait.php
+++ b/src/Model/Entity/ReadTrait.php
@@ -2,6 +2,7 @@
 
 namespace Shim\Model\Entity;
 
+use ArrayAccess;
 use Cake\Datasource\EntityInterface;
 
 /**
@@ -29,7 +30,7 @@ trait ReadTrait {
 
 		$data = null;
 		foreach ($parts as $key) {
-			if (!isset($this->$key)) {
+			if ($data === null && !isset($this->$key)) {
 				return $default;
 			}
 			if ($data === null) {
@@ -42,7 +43,7 @@ trait ReadTrait {
 				$data = $data->toArray();
 			}
 
-			if (isset($data[$key])) {
+			if ((is_array($data) || $data instanceof ArrayAccess) && isset($data[$key])) {
 				$data = $data[$key];
 			} else {
 				return $default;

--- a/src/Model/Entity/RequireTrait.php
+++ b/src/Model/Entity/RequireTrait.php
@@ -28,11 +28,7 @@ trait RequireTrait {
 	 * @return void
 	 */
 	public function require($path): void {
-		if (!is_array($path)) {
-			$parts = explode('.', $path);
-		} else {
-			$parts = $path;
-		}
+		$parts = is_array($path) ? $path : explode('.', $path);
 
 		$data = null;
 		$failed = null;

--- a/src/Model/Table/Table.php
+++ b/src/Model/Table/Table.php
@@ -353,43 +353,43 @@ class Table extends CoreTable {
 		if ($keyField === null && $valueField === null && count($fields) === 2) {
 			$keyField = array_shift($fields);
 			$valueField = array_shift($fields);
-			if (substr_count((string) $keyField, '.') > 1) {
+			if (substr_count((string)$keyField, '.') > 1) {
 				$keyField = null;
-			} elseif (str_contains((string) $keyField, '.')) {
-				$dotPos = (int)strpos((string) $keyField, '.');
-				if (substr((string) $keyField, 0, $dotPos) === $this->getAlias()) {
-					$keyField = substr((string) $keyField, $dotPos + 1);
+			} elseif (str_contains((string)$keyField, '.')) {
+				$dotPos = (int)strpos((string)$keyField, '.');
+				if (substr((string)$keyField, 0, $dotPos) === $this->getAlias()) {
+					$keyField = substr((string)$keyField, $dotPos + 1);
 				} else {
-					$modelAlias = substr((string) $keyField, 0, $dotPos);
+					$modelAlias = substr((string)$keyField, 0, $dotPos);
 					$property = $this->{$modelAlias}->getProperty();
-					$keyField = $property . '.' . substr((string) $keyField, $dotPos + 1);
+					$keyField = $property . '.' . substr((string)$keyField, $dotPos + 1);
 				}
 			}
-			if (substr_count((string) $valueField, '.') > 1) {
+			if (substr_count((string)$valueField, '.') > 1) {
 				$valueField = null;
-			} elseif (str_contains((string) $valueField, '.')) {
-				$dotPos = (int)strpos((string) $valueField, '.');
-				if (substr((string) $valueField, 0, $dotPos) === $this->getAlias()) {
-					$valueField = substr((string) $valueField, $dotPos + 1);
+			} elseif (str_contains((string)$valueField, '.')) {
+				$dotPos = (int)strpos((string)$valueField, '.');
+				if (substr((string)$valueField, 0, $dotPos) === $this->getAlias()) {
+					$valueField = substr((string)$valueField, $dotPos + 1);
 				} else {
-					$modelAlias = substr((string) $valueField, 0, $dotPos);
+					$modelAlias = substr((string)$valueField, 0, $dotPos);
 					$property = $this->{$modelAlias}->getProperty();
-					$valueField = $property . '.' . substr((string) $valueField, $dotPos + 1);
+					$valueField = $property . '.' . substr((string)$valueField, $dotPos + 1);
 				}
 			}
 
 		} elseif ($keyField === null && $valueField === null && count($fields) === 1) {
 			$field = array_shift($fields);
-			if (substr_count((string) $field, '.') > 1) {
+			if (substr_count((string)$field, '.') > 1) {
 				$field = null;
-			} elseif (str_contains((string) $field, '.')) {
-				$dotPos = (int)strpos((string) $field, '.');
-				if (substr((string) $field, 0, $dotPos) === $this->getAlias()) {
-					$field = substr((string) $field, $dotPos + 1);
+			} elseif (str_contains((string)$field, '.')) {
+				$dotPos = (int)strpos((string)$field, '.');
+				if (substr((string)$field, 0, $dotPos) === $this->getAlias()) {
+					$field = substr((string)$field, $dotPos + 1);
 				} else {
-					$modelAlias = substr((string) $field, 0, $dotPos);
+					$modelAlias = substr((string)$field, 0, $dotPos);
 					$property = $this->{$modelAlias}->getProperty();
-					$field = $property . '.' . substr((string) $field, $dotPos + 1);
+					$field = $property . '.' . substr((string)$field, $dotPos + 1);
 				}
 			}
 			if ($field !== null) {

--- a/src/Model/Table/Table.php
+++ b/src/Model/Table/Table.php
@@ -58,20 +58,20 @@ class Table extends CoreTable {
 	 */
 	public function initialize(array $config): void {
 		// Shims
-		if (isset($this->useTable)) {
+		if (property_exists($this, 'useTable') && $this->useTable !== null) {
 			$this->setTable($this->useTable);
 		}
-		if (isset($this->primaryKey)) {
+		if (property_exists($this, 'primaryKey') && $this->primaryKey !== null) {
 			$this->setPrimaryKey($this->primaryKey);
 		}
-		if (isset($this->displayField)) {
+		if (property_exists($this, 'displayField') && $this->displayField !== null) {
 			$this->setDisplayField($this->displayField);
 		}
 		$this->_shimRelations();
 
 		$this->_prefixOrderProperty();
 
-		if (isset($this->actsAs)) {
+		if (property_exists($this, 'actsAs') && $this->actsAs !== null) {
 			foreach ($this->actsAs as $name => $options) {
 				if (is_numeric($name)) {
 					$name = $options;
@@ -162,9 +162,7 @@ class Table extends CoreTable {
 			$array['conditions'] = $conditions;
 		}
 
-		$array = array_filter($array);
-
-		return $array;
+		return array_filter($array);
 	}
 
 	/**
@@ -355,43 +353,43 @@ class Table extends CoreTable {
 		if ($keyField === null && $valueField === null && count($fields) === 2) {
 			$keyField = array_shift($fields);
 			$valueField = array_shift($fields);
-			if (substr_count($keyField, '.') > 1) {
+			if (substr_count((string) $keyField, '.') > 1) {
 				$keyField = null;
-			} elseif (str_contains($keyField, '.')) {
-				$dotPos = (int)strpos($keyField, '.');
-				if (substr($keyField, 0, $dotPos) === $this->getAlias()) {
-					$keyField = substr($keyField, $dotPos + 1);
+			} elseif (str_contains((string) $keyField, '.')) {
+				$dotPos = (int)strpos((string) $keyField, '.');
+				if (substr((string) $keyField, 0, $dotPos) === $this->getAlias()) {
+					$keyField = substr((string) $keyField, $dotPos + 1);
 				} else {
-					$modelAlias = substr($keyField, 0, $dotPos);
+					$modelAlias = substr((string) $keyField, 0, $dotPos);
 					$property = $this->{$modelAlias}->getProperty();
-					$keyField = $property . '.' . substr($keyField, $dotPos + 1);
+					$keyField = $property . '.' . substr((string) $keyField, $dotPos + 1);
 				}
 			}
-			if (substr_count($valueField, '.') > 1) {
+			if (substr_count((string) $valueField, '.') > 1) {
 				$valueField = null;
-			} elseif (str_contains($valueField, '.')) {
-				$dotPos = (int)strpos($valueField, '.');
-				if (substr($valueField, 0, $dotPos) === $this->getAlias()) {
-					$valueField = substr($valueField, $dotPos + 1);
+			} elseif (str_contains((string) $valueField, '.')) {
+				$dotPos = (int)strpos((string) $valueField, '.');
+				if (substr((string) $valueField, 0, $dotPos) === $this->getAlias()) {
+					$valueField = substr((string) $valueField, $dotPos + 1);
 				} else {
-					$modelAlias = substr($valueField, 0, $dotPos);
+					$modelAlias = substr((string) $valueField, 0, $dotPos);
 					$property = $this->{$modelAlias}->getProperty();
-					$valueField = $property . '.' . substr($valueField, $dotPos + 1);
+					$valueField = $property . '.' . substr((string) $valueField, $dotPos + 1);
 				}
 			}
 
 		} elseif ($keyField === null && $valueField === null && count($fields) === 1) {
 			$field = array_shift($fields);
-			if (substr_count($field, '.') > 1) {
+			if (substr_count((string) $field, '.') > 1) {
 				$field = null;
-			} elseif (str_contains($field, '.')) {
-				$dotPos = (int)strpos($field, '.');
-				if (substr($field, 0, $dotPos) === $this->getAlias()) {
-					$field = substr($field, $dotPos + 1);
+			} elseif (str_contains((string) $field, '.')) {
+				$dotPos = (int)strpos((string) $field, '.');
+				if (substr((string) $field, 0, $dotPos) === $this->getAlias()) {
+					$field = substr((string) $field, $dotPos + 1);
 				} else {
-					$modelAlias = substr($field, 0, $dotPos);
+					$modelAlias = substr((string) $field, 0, $dotPos);
 					$property = $this->{$modelAlias}->getProperty();
-					$field = $property . '.' . substr($field, $dotPos + 1);
+					$field = $property . '.' . substr((string) $field, $dotPos + 1);
 				}
 			}
 			if ($field !== null) {
@@ -629,7 +627,7 @@ class Table extends CoreTable {
 	 * @return string
 	 */
 	protected function _prefixAlias(string $string): string {
-		if (strpos($string, '.') === false) {
+		if (!str_contains($string, '.')) {
 			return $this->getAlias() . '.' . $string;
 		}
 

--- a/src/Model/Table/Table.php
+++ b/src/Model/Table/Table.php
@@ -58,20 +58,20 @@ class Table extends CoreTable {
 	 */
 	public function initialize(array $config): void {
 		// Shims
-		if (property_exists($this, 'useTable') && $this->useTable !== null) {
+		if (isset($this->useTable)) {
 			$this->setTable($this->useTable);
 		}
-		if (property_exists($this, 'primaryKey') && $this->primaryKey !== null) {
+		if (isset($this->primaryKey)) {
 			$this->setPrimaryKey($this->primaryKey);
 		}
-		if (property_exists($this, 'displayField') && $this->displayField !== null) {
+		if (isset($this->displayField)) {
 			$this->setDisplayField($this->displayField);
 		}
 		$this->_shimRelations();
 
 		$this->_prefixOrderProperty();
 
-		if (property_exists($this, 'actsAs') && $this->actsAs !== null) {
+		if (isset($this->actsAs)) {
 			foreach ($this->actsAs as $name => $options) {
 				if (is_numeric($name)) {
 					$name = $options;

--- a/src/TestSuite/TestTrait.php
+++ b/src/TestSuite/TestTrait.php
@@ -47,7 +47,8 @@ trait TestTrait {
 		if (!$onlyVeryVerbose && in_array('-v', $_SERVER['argv'], true)) {
 			return true;
 		}
-        return in_array('-vv', $_SERVER['argv'], true);
+
+		return in_array('-vv', $_SERVER['argv'], true);
 	}
 
 	/**

--- a/src/TestSuite/TestTrait.php
+++ b/src/TestSuite/TestTrait.php
@@ -47,11 +47,7 @@ trait TestTrait {
 		if (!$onlyVeryVerbose && in_array('-v', $_SERVER['argv'], true)) {
 			return true;
 		}
-		if (in_array('-vv', $_SERVER['argv'], true)) {
-			return true;
-		}
-
-		return false;
+        return in_array('-vv', $_SERVER['argv'], true);
 	}
 
 	/**

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -336,10 +336,10 @@ class DateTimeWidget extends BasicWidget {
 		$options += ['interval' => 1, 'round' => null];
 		$changeValue = $value * (1 / $options['interval']);
 		$changeValue = match ($options['round']) {
-            'up' => ceil($changeValue),
-            'down' => floor($changeValue),
-            default => round($changeValue),
-        };
+			'up' => ceil($changeValue),
+			'down' => floor($changeValue),
+			default => round($changeValue),
+		};
 
 		return (int)($changeValue * $options['interval']) - $value;
 	}
@@ -678,7 +678,7 @@ class DateTimeWidget extends BasicWidget {
 			$dateTime['hour'] = 0;
 		}
 		if (isset($dateTime['meridian'])) {
-			$dateTime['hour'] = strtolower((string) $dateTime['meridian']) === 'am' ? $dateTime['hour'] : $dateTime['hour'] + 12;
+			$dateTime['hour'] = strtolower((string)$dateTime['meridian']) === 'am' ? $dateTime['hour'] : $dateTime['hour'] + 12;
 		}
 
 		return sprintf(

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -264,7 +264,7 @@ class DateTimeWidget extends BasicWidget {
 					'meridian' => '',
 				];
 				$validDate = false;
-				foreach ($dateArray as $key => $dateValue) {
+				foreach (array_keys($dateArray) as $key) {
 					$exists = isset($value[$key]);
 					if ($exists) {
 						$validDate = true;
@@ -295,7 +295,7 @@ class DateTimeWidget extends BasicWidget {
 				/** @var \DateTimeInterface|\Cake\Chronos\ChronosDate $value */
 				$dateTime = clone $value;
 			}
-		} catch (Exception $e) {
+		} catch (Exception) {
 			$dateTime = new DateTime();
 		}
 
@@ -335,18 +335,11 @@ class DateTimeWidget extends BasicWidget {
 	protected function _adjustValue(int $value, array $options): int {
 		$options += ['interval' => 1, 'round' => null];
 		$changeValue = $value * (1 / $options['interval']);
-		switch ($options['round']) {
-			case 'up':
-				$changeValue = ceil($changeValue);
-
-				break;
-			case 'down':
-				$changeValue = floor($changeValue);
-
-				break;
-			default:
-				$changeValue = round($changeValue);
-		}
+		$changeValue = match ($options['round']) {
+            'up' => ceil($changeValue),
+            'down' => floor($changeValue),
+            default => round($changeValue),
+        };
 
 		return (int)($changeValue * $options['interval']) - $value;
 	}
@@ -685,9 +678,10 @@ class DateTimeWidget extends BasicWidget {
 			$dateTime['hour'] = 0;
 		}
 		if (isset($dateTime['meridian'])) {
-			$dateTime['hour'] = strtolower($dateTime['meridian']) === 'am' ? $dateTime['hour'] : $dateTime['hour'] + 12;
+			$dateTime['hour'] = strtolower((string) $dateTime['meridian']) === 'am' ? $dateTime['hour'] : $dateTime['hour'] + 12;
 		}
-		$format = sprintf(
+
+		return sprintf(
 			'%d-%02d-%02d %02d:%02d:%02d',
 			$dateTime['year'],
 			$dateTime['month'],
@@ -696,8 +690,6 @@ class DateTimeWidget extends BasicWidget {
 			$dateTime['minute'],
 			$dateTime['second'],
 		);
-
-		return $format;
 	}
 
 }

--- a/tests/TestCase/Annotator/ClassAnnotatorTask/LegacyModelAwareClassAnnotatorTaskTest.php
+++ b/tests/TestCase/Annotator/ClassAnnotatorTask/LegacyModelAwareClassAnnotatorTaskTest.php
@@ -21,8 +21,6 @@ class LegacyModelAwareClassAnnotatorTaskTest extends TestCase {
 	 * @return void
 	 */
 	protected function setUp(): void {
-		parent::setUp();
-
 		$this->skipIf(version_compare(PHP_VERSION, '8.3.0', '<'));
 
 		$this->out = new ConsoleOutput();

--- a/tests/TestCase/Database/Type/TimeStringTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeStringTypeTest.php
@@ -30,8 +30,6 @@ class TimeStringTypeTest extends TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
-		parent::setUp();
-
 		TypeFactory::map('time', TimeStringType::class);
 
 		$this->Table = TableRegistry::getTableLocator()->get('TimeStringTypes', ['className' => TimeTypesTable::class]);
@@ -41,8 +39,6 @@ class TimeStringTypeTest extends TestCase {
 	 * @return void
 	 */
 	public function tearDown(): void {
-		parent::tearDown();
-
 		unset($this->Table);
 		TypeFactory::map('time', TimeType::class);
 	}

--- a/tests/TestCase/Database/Type/YearTypeTest.php
+++ b/tests/TestCase/Database/Type/YearTypeTest.php
@@ -27,8 +27,6 @@ class YearTypeTest extends TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
-		parent::setUp();
-
 		TypeFactory::map('year', YearType::class);
 
 		$this->Table = TableRegistry::getTableLocator()->get('YearTypes', ['className' => YearTypesTable::class]);
@@ -38,8 +36,6 @@ class YearTypeTest extends TestCase {
 	 * @return void
 	 */
 	public function tearDown(): void {
-		parent::tearDown();
-
 		unset($this->Table);
 	}
 

--- a/tests/TestCase/DeprecationsTest.php
+++ b/tests/TestCase/DeprecationsTest.php
@@ -12,6 +12,7 @@ class DeprecationsTest extends TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
+		parent::setUp();
 		Configure::delete('Shim.deprecations');
 	}
 
@@ -20,6 +21,7 @@ class DeprecationsTest extends TestCase {
 	 */
 	public function tearDown(): void {
 		Configure::delete('Shim.deprecations');
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/TestCase/DeprecationsTest.php
+++ b/tests/TestCase/DeprecationsTest.php
@@ -13,8 +13,6 @@ class DeprecationsTest extends TestCase {
 	 */
 	public function setUp(): void {
 		Configure::delete('Shim.deprecations');
-
-		parent::setUp();
 	}
 
 	/**
@@ -22,8 +20,6 @@ class DeprecationsTest extends TestCase {
 	 */
 	public function tearDown(): void {
 		Configure::delete('Shim.deprecations');
-
-		parent::tearDown();
 	}
 
 	/**

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -545,7 +545,7 @@ class FileTest extends TestCase {
 			$r = $TmpFile->append($fragment);
 			$this->assertTrue($r);
 			$this->assertFileExists($tmpFile);
-			$data = $data . $fragment;
+			$data .= $fragment;
 			$this->assertStringEqualsFile($tmpFile, $data);
 			$newSize = $TmpFile->size();
 			$this->assertTrue($newSize > $size);

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -45,7 +45,6 @@ class FolderTest extends TestCase {
 	 * @return void
 	 */
 	public function tearDown(): void {
-		parent::tearDown();
 		$cleaner = function ($dir) use (&$cleaner): void {
 			$files = array_diff(scandir($dir), ['.', '..']);
 			foreach ($files as $file) {

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1170,18 +1170,18 @@ class FolderTest extends TestCase {
 		touch($fileOneA);
 		touch($fileTwoB);
 
-		return [
-			'path' => $path,
-			'folderOne' => $folderOne,
-			'folderOneA' => $folderOneA,
-			'folderTwo' => $folderTwo,
-			'folderTwoB' => $folderTwoB,
-			'folderThree' => $folderThree,
-			'fileOne' => $fileOne,
-			'fileOneA' => $fileOneA,
-			'fileTwo' => $fileTwo,
-			'fileTwoB' => $fileTwoB,
-		];
+		return compact(
+			'path',
+			'folderOne',
+			'folderOneA',
+			'folderTwo',
+			'folderTwoB',
+			'folderThree',
+			'fileOne',
+			'fileOneA',
+			'fileTwo',
+			'fileTwoB',
+		);
 	}
 
 	/**

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1170,7 +1170,18 @@ class FolderTest extends TestCase {
 		touch($fileOneA);
 		touch($fileTwoB);
 
-		return ['path' => $path, 'folderOne' => $folderOne, 'folderOneA' => $folderOneA, 'folderTwo' => $folderTwo, 'folderTwoB' => $folderTwoB, 'folderThree' => $folderThree, 'fileOne' => $fileOne, 'fileOneA' => $fileOneA, 'fileTwo' => $fileTwo, 'fileTwoB' => $fileTwoB];
+		return [
+			'path' => $path,
+			'folderOne' => $folderOne,
+			'folderOneA' => $folderOneA,
+			'folderTwo' => $folderTwo,
+			'folderTwoB' => $folderTwoB,
+			'folderThree' => $folderThree,
+			'fileOne' => $fileOne,
+			'fileOneA' => $fileOneA,
+			'fileTwo' => $fileTwo,
+			'fileTwoB' => $fileTwoB,
+		];
 	}
 
 	/**

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1171,18 +1171,7 @@ class FolderTest extends TestCase {
 		touch($fileOneA);
 		touch($fileTwoB);
 
-		return compact(
-			'path',
-			'folderOne',
-			'folderOneA',
-			'folderTwo',
-			'folderTwoB',
-			'folderThree',
-			'fileOne',
-			'fileOneA',
-			'fileTwo',
-			'fileTwoB',
-		);
+		return ['path' => $path, 'folderOne' => $folderOne, 'folderOneA' => $folderOneA, 'folderTwo' => $folderTwo, 'folderTwoB' => $folderTwoB, 'folderThree' => $folderThree, 'fileOne' => $fileOne, 'fileOneA' => $fileOneA, 'fileTwo' => $fileTwo, 'fileTwoB' => $fileTwoB];
 	}
 
 	/**

--- a/tests/TestCase/Model/Behavior/NullableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/NullableBehaviorTest.php
@@ -24,8 +24,6 @@ class NullableBehaviorTest extends TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
-		parent::setUp();
-
 		$this->Table = TableRegistry::getTableLocator()->get('Nullables');
 		$this->Table->addAssociations(['hasOne' => ['NullableTenants' => ['hasMany' => 'Nullables']]]);
 		$this->Table->addBehavior('Shim.Nullable');
@@ -35,8 +33,6 @@ class NullableBehaviorTest extends TestCase {
 	 * @return void
 	 */
 	public function tearDown(): void {
-		parent::tearDown();
-
 		$this->getTableLocator()->clear();
 	}
 

--- a/tests/TestCase/Model/Table/TableTest.php
+++ b/tests/TestCase/Model/Table/TableTest.php
@@ -41,8 +41,6 @@ class TableTest extends TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
-		parent::setUp();
-
 		Configure::write('App.namespace', 'TestApp');
 
 		$this->Posts = TableRegistry::getTableLocator()->get('Shim.Posts', ['className' => '\Shim\Model\Table\Table']);
@@ -57,8 +55,6 @@ class TableTest extends TestCase {
 	 */
 	public function tearDown(): void {
 		Configure::delete('Shim');
-
-		parent::tearDown();
 	}
 
 	/**

--- a/tests/TestCase/Model/Table/TableTest.php
+++ b/tests/TestCase/Model/Table/TableTest.php
@@ -41,6 +41,8 @@ class TableTest extends TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		Configure::write('App.namespace', 'TestApp');
 
 		$this->Posts = TableRegistry::getTableLocator()->get('Shim.Posts', ['className' => '\Shim\Model\Table\Table']);
@@ -55,6 +57,8 @@ class TableTest extends TestCase {
 	 */
 	public function tearDown(): void {
 		Configure::delete('Shim');
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/TestCase/View/Helper/CookieHelperTest.php
+++ b/tests/TestCase/View/Helper/CookieHelperTest.php
@@ -18,8 +18,6 @@ class CookieHelperTest extends TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
-		parent::setUp();
-
 		/** @var \Cake\Http\ServerRequest|\PHPUnit\Framework\MockObject\MockObject $request */
 		$this->request = $this->getMockBuilder(ServerRequest::class)->onlyMethods(['getCookie', 'getCookieParams'])->getMock();
 		$this->Cookie = new CookieHelper(new View($this->request));
@@ -30,8 +28,6 @@ class CookieHelperTest extends TestCase {
 	 */
 	public function tearDown(): void {
 		unset($this->Table);
-
-		parent::tearDown();
 	}
 
 	/**

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -15,6 +15,8 @@ class NumberHelperTest extends TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		$request = new ServerRequest();
 		$this->Number = new NumberHelper(new View($request));
 	}
@@ -24,6 +26,7 @@ class NumberHelperTest extends TestCase {
 	 */
 	public function tearDown(): void {
 		unset($this->Table);
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -15,8 +15,6 @@ class NumberHelperTest extends TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
-		parent::setUp();
-
 		$request = new ServerRequest();
 		$this->Number = new NumberHelper(new View($request));
 	}
@@ -26,8 +24,6 @@ class NumberHelperTest extends TestCase {
 	 */
 	public function tearDown(): void {
 		unset($this->Table);
-
-		parent::tearDown();
 	}
 
 	/**

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -18,7 +18,7 @@ foreach ($iterator as $file) {
 	$class = 'Shim\\Test\\Fixture\\' . $name . 'Fixture';
 	try {
 		$object = (new ReflectionClass($class))->getProperty('fields');
-	} catch (ReflectionException $e) {
+	} catch (ReflectionException) {
 		continue;
 	}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.