### PR TITLE
Keep iterable value type on entity setters with genericsInParam

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -35,4 +35,15 @@ return [
 		// Helps catch stray output/whitespace in controllers. Default: not set (disabled).
 		'monitorHeaders' => false,
 	],
+
+	// This key is owned by dereuromark/cakephp-ide-helper (see that plugin's
+	// config/app.example.php for the full set of options). Shim's EntityAnnotator
+	// honors it too: when enabled (true, or 'detailed' for fully detailed types),
+	// generated entity setter methods keep the iterable value type of array/json
+	// fields, e.g. setTagsOrFail(array<\App\Model\Entity\Tag> $value) instead of a
+	// bare setTagsOrFail(array $value). Without it the value type collapses to the
+	// base type. Default: false.
+	'IdeHelper' => [
+		'genericsInParam' => false,
+	],
 ];

--- a/src/Annotator/EntityAnnotator.php
+++ b/src/Annotator/EntityAnnotator.php
@@ -2,6 +2,7 @@
 
 namespace Shim\Annotator;
 
+use Cake\Core\Configure;
 use Cake\Utility\Inflector;
 use IdeHelper\Annotation\MethodAnnotation;
 use IdeHelper\Annotator\EntityAnnotator as IdeHelperEntityAnnotator;
@@ -41,7 +42,11 @@ class EntityAnnotator extends IdeHelperEntityAnnotator {
 					if (str_contains((string)$type, '|null')) {
 						$type = str_replace('|null', '', $type);
 					}
-					if (preg_match('/^(\w+)[<\[]/', (string)$type, $matches)) {
+					// With `IdeHelper.genericsInParam` the property hint already carries the
+					// value type (e.g. `array<\App\Model\Entity\User>`); keep it so the setter
+					// param stays PHPStan-clean (no `missingType.iterableValue`). Without the
+					// opt-in, collapse generics to the base type for backwards compatibility.
+					if (!Configure::read('IdeHelper.genericsInParam') && preg_match('/^(\w+)[<\[]/', (string)$type, $matches)) {
 						$type = $matches[1];
 					}
 

--- a/tests/TestCase/Annotator/EntityAnnotatorTest.php
+++ b/tests/TestCase/Annotator/EntityAnnotatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Shim\Test\TestCase\Annotator;
 
+use Cake\Core\Configure;
 use Cake\I18n\DateTime;
 use Cake\View\View;
 use IdeHelper\View\Helper\DocBlockHelper;
@@ -32,6 +33,55 @@ class EntityAnnotatorTest extends TestCase {
 		$this->assertSame('\\' . DateTime::class . '|null $foo_bar', $result['foo_bar']->build());
 		$this->assertSame('int getIdOrFail()', $result['getIdOrFail()']->build());
 		$this->assertSame('\\' . DateTime::class . ' getFooBarOrFail()', $result['getFooBarOrFail()']->build());
+	}
+
+	/**
+	 * With `IdeHelper.genericsInParam` the iterable value type of an array/json
+	 * field must survive on the setter param, so PHPStan stays clean.
+	 *
+	 * @return void
+	 */
+	public function testBuildAnnotationsKeepsSetterValueTypeWithGenericsInParam(): void {
+		Configure::write('IdeHelper.genericsInParam', true);
+
+		/** @var \Shim\Annotator\EntityAnnotator $entityAnnotator */
+		$entityAnnotator = $this->getMockBuilder(EntityAnnotator::class)->disableOriginalConstructor()->onlyMethods(['annotate'])->getMock();
+		$entityAnnotator->setConfig('class', TestEntity::class);
+
+		$propertyHintMap = ['tags' => 'array<\\' . DateTime::class . '>'];
+		$helper = new DocBlockHelper(new View());
+		$helper->setVirtualFields([]);
+
+		/** @var array<\IdeHelper\Annotation\AbstractAnnotation> $result */
+		$result = $this->invokeMethod($entityAnnotator, 'buildAnnotations', [$propertyHintMap, $helper]);
+
+		$key = 'setTagsOrFail(array<\\' . DateTime::class . '> $value)';
+		$this->assertArrayHasKey($key, $result);
+		$this->assertSame('$this ' . $key, $result[$key]->build());
+	}
+
+	/**
+	 * Without the opt-in the generic collapses to the base type for backwards
+	 * compatibility.
+	 *
+	 * @return void
+	 */
+	public function testBuildAnnotationsCollapsesSetterValueTypeByDefault(): void {
+		Configure::delete('IdeHelper.genericsInParam');
+
+		/** @var \Shim\Annotator\EntityAnnotator $entityAnnotator */
+		$entityAnnotator = $this->getMockBuilder(EntityAnnotator::class)->disableOriginalConstructor()->onlyMethods(['annotate'])->getMock();
+		$entityAnnotator->setConfig('class', TestEntity::class);
+
+		$propertyHintMap = ['tags' => 'array<\\' . DateTime::class . '>'];
+		$helper = new DocBlockHelper(new View());
+		$helper->setVirtualFields([]);
+
+		/** @var array<\IdeHelper\Annotation\AbstractAnnotation> $result */
+		$result = $this->invokeMethod($entityAnnotator, 'buildAnnotations', [$propertyHintMap, $helper]);
+
+		$this->assertArrayHasKey('setTagsOrFail(array $value)', $result);
+		$this->assertSame('$this setTagsOrFail(array $value)', $result['setTagsOrFail(array $value)']->build());
 	}
 
 	/**


### PR DESCRIPTION
## Problem

With IdeHelper.genericsInParam enabled, entity setters for array/json fields were emitted with a bare array param:

```php
/**
 * @method $this setUsersOrFail(array $value)
 */
```

which trips PHPStan's missingType.iterableValue.

## Cause

EntityAnnotator collapsed any generic/array property hint to its base type before building the setter param:

```php
if (preg_match('/^(\w+)[<\[]/', (string)$type, $matches)) {
    $type = $matches[1];
}
```

So `array<\App\Model\Entity\User>` became `array`.

## Change

Honor the opt-in: when IdeHelper.genericsInParam is set, keep the full value type the property hint already carries:

```php
/**
 * @method $this setUsersOrFail(array<\App\Model\Entity\User> $value)
 */
```

Without the opt-in the generic still collapses to the base type, so default output is unchanged (backwards compatible). Mirrors ide-helper's own genericsInParam handling in ModelAnnotator. Added EntityAnnotatorTest coverage for both modes.
