### PR TITLE
Carry event subject generic on Controller::afterFilter

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -64,7 +64,7 @@ class Controller extends CoreController {
 	 * This, if desired, adds a check if your controller actions are cleanly built and no headers
 	 * or output is being sent prior to the response class, which should be the only one doing this.
 	 *
-	 * @param \Cake\Event\EventInterface $event An Event instance
+	 * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event An Event instance
 	 * @throws \Exception
 	 * @return void
 	 */


### PR DESCRIPTION
## Problem

Subclasses overriding afterFilter() with the generic event form hit PHPStan's method.childParameterType (contravariance):

> Parameter #1 $event (Cake\Event\EventInterface<Cake\Controller\Controller>) of method App\Controller\ExportController::afterFilter() should be contravariant with parameter $event (Cake\Event\EventInterface) of method Shim\Controller\Controller::afterFilter()

## Cause

Shim's Controller documented a bare event interface on afterFilter, while Cake's own Controller uses the generic form:

```php
// Cake\Controller\Controller
/**
 * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event An Event instance
 */
public function afterFilter(EventInterface $event)
```

## Change

Match Cake's base so generic-typed overrides stay LSP-compatible:

```php
/**
 * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event An Event instance
 */
public function afterFilter(EventInterface $event): void
```

Doc-block only; no runtime behavior change.
